### PR TITLE
feature: preview color theme on enable hover

### DIFF
--- a/packages/e2e/fixtures/extension-detail-theme-missing/extension.json
+++ b/packages/e2e/fixtures/extension-detail-theme-missing/extension.json
@@ -1,0 +1,13 @@
+{
+  "id": "test.theme-missing-test",
+  "name": "Missing Theme",
+  "description": "Missing Theme",
+  "categories": ["Themes"],
+  "colorThemes": [
+    {
+      "id": "missing-theme",
+      "label": "Missing Theme",
+      "path": "missing-color-theme.json"
+    }
+  ]
+}

--- a/packages/e2e/src/extension-detail.preview-color-theme-invalid.ts
+++ b/packages/e2e/src/extension-detail.preview-color-theme-invalid.ts
@@ -1,0 +1,26 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.preview-color-theme-invalid'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const slimeExtensionUri = import.meta.resolve('../fixtures/extension-detail-slime-theme')
+  const extensionUri = import.meta.resolve('../fixtures/extension-detail-theme-invalid')
+  await Extension.addWebExtension(slimeExtensionUri)
+  await Extension.addWebExtension(extensionUri)
+  await Command.execute('ColorTheme.setColorTheme', 'slime-theme')
+  await ExtensionDetail.open('test.theme-test')
+  await ExtensionDetail.handleClickDisable()
+  const enableButton = Locator('.ExtensionDetail [name="Enable"]')
+  await expect(enableButton).toBeVisible()
+  const activityBar = Locator('.ActivityBar')
+  await expect(activityBar).toHaveCSS('background-color', 'rgb(132, 204, 22)')
+
+  // act
+  await enableButton.hover()
+
+  // assert
+  await expect(activityBar).toHaveCSS('background-color', 'rgb(132, 204, 22)')
+}

--- a/packages/e2e/src/extension-detail.preview-color-theme-missing.ts
+++ b/packages/e2e/src/extension-detail.preview-color-theme-missing.ts
@@ -1,0 +1,26 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.preview-color-theme-missing'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const slimeExtensionUri = import.meta.resolve('../fixtures/extension-detail-slime-theme')
+  const extensionUri = import.meta.resolve('../fixtures/extension-detail-theme-missing')
+  await Extension.addWebExtension(slimeExtensionUri)
+  await Extension.addWebExtension(extensionUri)
+  await Command.execute('ColorTheme.setColorTheme', 'slime-theme')
+  await ExtensionDetail.open('test.theme-missing-test')
+  await ExtensionDetail.handleClickDisable()
+  const enableButton = Locator('.ExtensionDetail [name="Enable"]')
+  await expect(enableButton).toBeVisible()
+  const activityBar = Locator('.ActivityBar')
+  await expect(activityBar).toHaveCSS('background-color', 'rgb(132, 204, 22)')
+
+  // act
+  await enableButton.hover()
+
+  // assert
+  await expect(activityBar).toHaveCSS('background-color', 'rgb(132, 204, 22)')
+}

--- a/packages/e2e/src/extension-detail.preview-color-theme.ts
+++ b/packages/e2e/src/extension-detail.preview-color-theme.ts
@@ -1,0 +1,32 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.preview-color-theme'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const slimeExtensionUri = import.meta.resolve('../fixtures/extension-detail-slime-theme')
+  const extensionUri = import.meta.resolve('../fixtures/extension-detail-theme')
+  await Extension.addWebExtension(slimeExtensionUri)
+  await Extension.addWebExtension(extensionUri)
+  await Command.execute('ColorTheme.setColorTheme', 'slime-theme')
+  await ExtensionDetail.open('test.theme-test')
+  await ExtensionDetail.handleClickDisable()
+  const enableButton = Locator('.ExtensionDetail [name="Enable"]')
+  await expect(enableButton).toBeVisible()
+  const activityBar = Locator('.ActivityBar')
+  await expect(activityBar).toHaveCSS('background-color', 'rgb(132, 204, 22)')
+
+  // act
+  await enableButton.hover()
+
+  // assert
+  await expect(activityBar).toHaveCSS('background-color', 'rgb(255, 165, 0)')
+
+  // act
+  await Locator('.ExtensionDetail').hover()
+
+  // assert
+  await expect(activityBar).toHaveCSS('background-color', 'rgb(132, 204, 22)')
+}

--- a/packages/extension-detail-view-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/extension-detail-view-worker/src/parts/CommandMap/CommandMap.ts
@@ -29,6 +29,8 @@ import { handleExtensionsChanged } from '../HandleExtensionsChanged/HandleExtens
 import * as HandleExtensionsStatusUpdate from '../HandleExtensionsStatusUpdate/HandleExtensionsStatusUpdate.ts'
 import * as HandleIconError from '../HandleIconError/HandleIconError.ts'
 import { handleImageContextMenu } from '../HandleImageContextMenu/HandleImageContextMenu.ts'
+import * as HandleMouseEnterEnable from '../HandleMouseEnterEnable/HandleMouseEnterEnable.ts'
+import * as HandleMouseLeaveEnable from '../HandleMouseLeaveEnable/HandleMouseLeaveEnable.ts'
 import * as HandleReadmeClick from '../HandleReadmeClick/HandleReadmeClick.ts'
 import { handleReadmeContextMenu } from '../HandleReadmeContextMenu/HandleReadmeContextMenu.ts'
 import { handleResourceLinkClick } from '../HandleResourceLinkClick/HandleResourceLinkClick.ts'
@@ -76,6 +78,8 @@ export const commandMap = {
   'ExtensionDetail.handleFeaturesClick': WrapCommand.wrapCommand(HandleClickFeatures.handleClickFeatures),
   'ExtensionDetail.handleIconError': WrapCommand.wrapCommand(HandleIconError.handleIconError),
   'ExtensionDetail.handleImageContextMenu': WrapCommand.wrapCommand(handleImageContextMenu),
+  'ExtensionDetail.handleMouseEnterEnable': WrapCommand.wrapCommand(HandleMouseEnterEnable.handleMouseEnterEnable),
+  'ExtensionDetail.handleMouseLeaveEnable': WrapCommand.wrapCommand(HandleMouseLeaveEnable.handleMouseLeaveEnable),
   'ExtensionDetail.handleReadmeClick': WrapCommand.wrapCommand(HandleReadmeClick.handleReadmeClick),
   'ExtensionDetail.handleReadmeContextMenu': WrapCommand.wrapCommand(handleReadmeContextMenu),
   'ExtensionDetail.handleResourceLinkClick': WrapCommand.wrapCommand(handleResourceLinkClick),

--- a/packages/extension-detail-view-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
+++ b/packages/extension-detail-view-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
@@ -17,3 +17,5 @@ export const HandleReadmeClick = 16
 export const HandleSelectionChange = 17
 export const HandleTabFocus = 18
 export const HandleResourceLinkClick = 19
+export const HandleMouseEnterEnable = 20
+export const HandleMouseLeaveEnable = 21

--- a/packages/extension-detail-view-worker/src/parts/GetButtonVirtualDom/GetButtonVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetButtonVirtualDom/GetButtonVirtualDom.ts
@@ -6,15 +6,21 @@ import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
 const className = MergeClassNames.mergeClassNames(ClassNames.Button, ClassNames.ButtonPrimary)
 
-export const getButtonVirtualDom = (message: string, onClick: string | number, name: string): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      className,
-      name,
-      onClick,
-      type: VirtualDomElements.Button,
-    },
-    text(message),
-  ]
+export const getButtonVirtualDom = (
+  message: string,
+  onClick: string | number,
+  name: string,
+  onMouseEnter?: string | number,
+  onMouseLeave?: string | number,
+): readonly VirtualDomNode[] => {
+  const button: VirtualDomNode = {
+    childCount: 1,
+    className,
+    name,
+    onClick,
+    ...(onMouseEnter ? { onMouseEnter } : {}),
+    ...(onMouseLeave ? { onMouseLeave } : {}),
+    type: VirtualDomElements.Button,
+  }
+  return [button, text(message)]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailButtons/ExtensionDetailButton.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailButtons/ExtensionDetailButton.ts
@@ -3,4 +3,6 @@ export interface ExtensionDetailButton {
   readonly label: string
   readonly name: string
   readonly onClick: string | number
+  readonly onMouseEnter?: string | number
+  readonly onMouseLeave?: string | number
 }

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailButtons/GetExtensionDetailButtons.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailButtons/GetExtensionDetailButtons.ts
@@ -30,6 +30,8 @@ export const getExtensionDetailButtons = (
       label: ExtensionDetailStrings.enable(),
       name: InputName.Enable,
       onClick: DomEventListenerFunctions.HandleClickEnable,
+      onMouseEnter: DomEventListenerFunctions.HandleMouseEnterEnable,
+      onMouseLeave: DomEventListenerFunctions.HandleMouseLeaveEnable,
     },
     {
       enabled: !isDisabled,

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailHeaderActionsVirtualDom/GetExtensionDetailHeaderActionsVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailHeaderActionsVirtualDom/GetExtensionDetailHeaderActionsVirtualDom.ts
@@ -11,7 +11,7 @@ export const getExtensionDetailHeaderActionsVirtualDom = (
 ): readonly VirtualDomNode[] => {
   const enabledButtons = buttonDefs.filter((btn) => btn.enabled)
   const buttons: readonly VirtualDomNode[] = enabledButtons.flatMap((btn: ExtensionDetailButton) =>
-    GetButtonVirtualDom.getButtonVirtualDom(btn.label, btn.onClick, btn.name),
+    GetButtonVirtualDom.getButtonVirtualDom(btn.label, btn.onClick, btn.name, btn.onMouseEnter, btn.onMouseLeave),
   )
   const settingsButton: readonly VirtualDomNode[] = GetSettingsButtonVirtualDom.getSettingsButtonVirtualDom(settingsButtonEnabled)
   const dom: readonly VirtualDomNode[] = [

--- a/packages/extension-detail-view-worker/src/parts/HandleMouseEnterEnable/HandleMouseEnterEnable.ts
+++ b/packages/extension-detail-view-worker/src/parts/HandleMouseEnterEnable/HandleMouseEnterEnable.ts
@@ -1,0 +1,16 @@
+import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
+import { getColorThemeId } from '../GetColorThemeId/GetColorThemeId.ts'
+import * as PreviewColorTheme from '../PreviewColorTheme/PreviewColorTheme.ts'
+
+export const handleMouseEnterEnable = async (state: ExtensionDetailState): Promise<ExtensionDetailState> => {
+  const colorThemeId = getColorThemeId(state.extension)
+  if (!colorThemeId) {
+    return state
+  }
+  try {
+    await PreviewColorTheme.previewColorTheme(colorThemeId)
+  } catch (error) {
+    console.warn(error)
+  }
+  return state
+}

--- a/packages/extension-detail-view-worker/src/parts/HandleMouseLeaveEnable/HandleMouseLeaveEnable.ts
+++ b/packages/extension-detail-view-worker/src/parts/HandleMouseLeaveEnable/HandleMouseLeaveEnable.ts
@@ -1,0 +1,11 @@
+import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
+import * as PreviewColorTheme from '../PreviewColorTheme/PreviewColorTheme.ts'
+
+export const handleMouseLeaveEnable = async (state: ExtensionDetailState): Promise<ExtensionDetailState> => {
+  try {
+    await PreviewColorTheme.disablePreviewColorTheme()
+  } catch (error) {
+    console.warn(error)
+  }
+  return state
+}

--- a/packages/extension-detail-view-worker/src/parts/PreviewColorTheme/PreviewColorTheme.ts
+++ b/packages/extension-detail-view-worker/src/parts/PreviewColorTheme/PreviewColorTheme.ts
@@ -1,0 +1,9 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const previewColorTheme = async (colorThemeId: string): Promise<void> => {
+  await RendererWorker.invoke('ColorTheme.previewColorTheme', colorThemeId)
+}
+
+export const disablePreviewColorTheme = async (): Promise<void> => {
+  await RendererWorker.invoke('ColorTheme.disablePreviewColorTheme')
+}

--- a/packages/extension-detail-view-worker/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/extension-detail-view-worker/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -59,6 +59,14 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
       params: ['handleClickEnable'],
     },
     {
+      name: DomEventListenerFunctions.HandleMouseEnterEnable,
+      params: ['handleMouseEnterEnable'],
+    },
+    {
+      name: DomEventListenerFunctions.HandleMouseLeaveEnable,
+      params: ['handleMouseLeaveEnable'],
+    },
+    {
       name: DomEventListenerFunctions.HandleClickScrollToTop,
       params: ['handleClickScrollToTop'],
       preventDefault: true,

--- a/packages/extension-detail-view-worker/test/GetButtonVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetButtonVirtualDom.test.ts
@@ -68,3 +68,18 @@ test('getButtonVirtualDom - with long message', () => {
     text('This is a very long button message that spans multiple words'),
   ])
 })
+
+test('getButtonVirtualDom - with hover listeners', () => {
+  expect(GetButtonVirtualDom.getButtonVirtualDom('Enable', 3, 'Enable', 20, 21)).toEqual([
+    {
+      childCount: 1,
+      className: MergeClassNames.mergeClassNames(ClassNames.Button, ClassNames.ButtonPrimary),
+      name: 'Enable',
+      onClick: 3,
+      onMouseEnter: 20,
+      onMouseLeave: 21,
+      type: VirtualDomElements.Button,
+    },
+    text('Enable'),
+  ])
+})

--- a/packages/extension-detail-view-worker/test/GetExtensionDetailButtons.test.ts
+++ b/packages/extension-detail-view-worker/test/GetExtensionDetailButtons.test.ts
@@ -72,3 +72,16 @@ test('set color theme button is not shown when active theme matches extension la
   const setColorThemeButton = result.find((button) => button.name === InputName.SetColorTheme)
   expect(setColorThemeButton).toBeUndefined()
 })
+
+test('enable button previews color theme on hover', () => {
+  const result: readonly ExtensionDetailButton[] = getExtensionDetailButtons(true, false, true, 'slime-theme', 'Slime Theme', 'other-theme')
+  const enableButton = result.find((button) => button.name === InputName.Enable)
+  expect(enableButton).toEqual({
+    enabled: true,
+    label: ExtensionDetailStrings.enable(),
+    name: InputName.Enable,
+    onClick: 3,
+    onMouseEnter: 20,
+    onMouseLeave: 21,
+  })
+})

--- a/packages/extension-detail-view-worker/test/HandleMouseEnterEnable.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleMouseEnterEnable.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as CreateDefaultState from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as HandleMouseEnterEnable from '../src/parts/HandleMouseEnterEnable/HandleMouseEnterEnable.ts'
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('handleMouseEnterEnable previews extension color theme', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ColorTheme.previewColorTheme': () => {},
+  })
+
+  const state = {
+    ...CreateDefaultState.createDefaultState(),
+    extension: {
+      colorThemes: [{ id: 'theme1', label: 'Theme 1' }],
+    },
+  }
+
+  const result = await HandleMouseEnterEnable.handleMouseEnterEnable(state)
+  expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([['ColorTheme.previewColorTheme', 'theme1']])
+})
+
+test('handleMouseEnterEnable does nothing without color theme', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({})
+
+  const state = {
+    ...CreateDefaultState.createDefaultState(),
+    extension: {},
+  }
+
+  const result = await HandleMouseEnterEnable.handleMouseEnterEnable(state)
+  expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([])
+})
+
+test('handleMouseEnterEnable handles preview error gracefully', async () => {
+  const error = new Error('Color theme not found')
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ColorTheme.previewColorTheme': () => {
+      throw error
+    },
+  })
+
+  const state = {
+    ...CreateDefaultState.createDefaultState(),
+    extension: {
+      colorThemes: [{ id: 'missing-theme', label: 'Missing Theme' }],
+    },
+  }
+
+  const result = await HandleMouseEnterEnable.handleMouseEnterEnable(state)
+  expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([['ColorTheme.previewColorTheme', 'missing-theme']])
+  expect(warn).toHaveBeenCalledWith(error)
+})

--- a/packages/extension-detail-view-worker/test/HandleMouseLeaveEnable.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleMouseLeaveEnable.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as CreateDefaultState from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as HandleMouseLeaveEnable from '../src/parts/HandleMouseLeaveEnable/HandleMouseLeaveEnable.ts'
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('handleMouseLeaveEnable disables color theme preview', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ColorTheme.disablePreviewColorTheme': () => {},
+  })
+
+  const state = CreateDefaultState.createDefaultState()
+  const result = await HandleMouseLeaveEnable.handleMouseLeaveEnable(state)
+  expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([['ColorTheme.disablePreviewColorTheme']])
+})
+
+test('handleMouseLeaveEnable handles restore error gracefully', async () => {
+  const error = new Error('Failed to restore color theme')
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ColorTheme.disablePreviewColorTheme': () => {
+      throw error
+    },
+  })
+
+  const state = CreateDefaultState.createDefaultState()
+  const result = await HandleMouseLeaveEnable.handleMouseLeaveEnable(state)
+  expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([['ColorTheme.disablePreviewColorTheme']])
+  expect(warn).toHaveBeenCalledWith(error)
+})

--- a/packages/extension-detail-view-worker/test/RenderEventListeners.test.ts
+++ b/packages/extension-detail-view-worker/test/RenderEventListeners.test.ts
@@ -1,7 +1,16 @@
 import { expect, test } from '@jest/globals'
+import * as DomEventListenerFunctions from '../src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as RenderEventListeners from '../src/parts/RenderEventListeners/RenderEventListeners.ts'
 
 test('renderEventListeners returns expected event listeners', () => {
   const result = RenderEventListeners.renderEventListeners()
   expect(result).toBeDefined()
+  expect(result).toContainEqual({
+    name: DomEventListenerFunctions.HandleMouseEnterEnable,
+    params: ['handleMouseEnterEnable'],
+  })
+  expect(result).toContainEqual({
+    name: DomEventListenerFunctions.HandleMouseLeaveEnable,
+    params: ['handleMouseLeaveEnable'],
+  })
 })


### PR DESCRIPTION
Adds color theme preview on the extension detail Enable button hover, restores the active theme on mouse leave, and covers graceful error handling for missing or invalid themes.