### PR TITLE
fix: style extension size link

### DIFF
--- a/packages/e2e/src/extension-detail.size-link.ts
+++ b/packages/e2e/src/extension-detail.size-link.ts
@@ -18,4 +18,5 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await expect(moreInfoEntryValue).toHaveText('0 B')
   await expect(moreInfoEntryValue).toHaveAttribute('tabIndex', '0')
   await expect(moreInfoEntryValue).toHaveCSS('cursor', 'pointer')
+  await expect(moreInfoEntryValue).toHaveCSS('text-decoration-line', 'none')
 }

--- a/packages/extension-detail-view-worker/src/parts/GetMoreInfoEntryValueVirtualDom/GetMoreInfoEntryValueVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetMoreInfoEntryValueVirtualDom/GetMoreInfoEntryValueVirtualDom.ts
@@ -22,7 +22,7 @@ const getExtraProps = (title: string | undefined, onClick: string | number | und
     props.title = title
   }
   if (onClick) {
-    props.style = 'cursor: pointer'
+    props.style = 'color: var(--vscode-textLink-foreground, #3794ff); cursor: pointer; text-decoration: none'
     props.tabIndex = 0
   }
   return props

--- a/packages/extension-detail-view-worker/test/GetMoreInfoEntryValueVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetMoreInfoEntryValueVirtualDom.test.ts
@@ -51,7 +51,7 @@ test('clickable value has pointer cursor', () => {
       childCount: 1,
       className: MergeClassNames.mergeClassNames(ClassNames.MoreInfoEntryValue, ClassNames.Link),
       onClick: 7,
-      style: 'cursor: pointer',
+      style: 'color: var(--vscode-textLink-foreground, #3794ff); cursor: pointer; text-decoration: none',
       tabIndex: 0,
       title: '/test/path',
       type: VirtualDomElements.A,


### PR DESCRIPTION
## Summary
- style clickable extension size values with VS Code link color
- remove underline from the size link display