### PR TITLE
fix: highlight extension readme code blocks

### DIFF
--- a/packages/e2e/fixtures/extension-readme-syntax-highlighting/README.md
+++ b/packages/e2e/fixtures/extension-readme-syntax-highlighting/README.md
@@ -1,0 +1,5 @@
+# Syntax Highlighting
+
+```js
+const answer = 42
+```

--- a/packages/e2e/fixtures/extension-readme-syntax-highlighting/extension.json
+++ b/packages/e2e/fixtures/extension-readme-syntax-highlighting/extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "test.extension-readme-syntax-highlighting",
+  "name": "Extension README Syntax Highlighting",
+  "description": "Tests fenced code block syntax highlighting.",
+  "version": "1.0.0"
+}

--- a/packages/e2e/src/extension-detail.readme-syntax-highlighting.ts
+++ b/packages/e2e/src/extension-detail.readme-syntax-highlighting.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const skip = 1
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-readme-syntax-highlighting')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-readme-syntax-highlighting')
+
+  const keyword = Locator('.ExtensionDetail .Markdown pre .Token.Keyword')
+  await expect(keyword).toHaveText('const')
+}

--- a/packages/extension-detail-view-worker/src/parts/Create/Create.ts
+++ b/packages/extension-detail-view-worker/src/parts/Create/Create.ts
@@ -39,6 +39,7 @@ export const create = (uid: number, uri: string, x: number, y: number, width: nu
     initial: true,
     installationEntries: [],
     jsonValidation: [],
+    languages: [],
     lastUpdated: null,
     linkProtectionEnabled: false,
     locationHost: '',

--- a/packages/extension-detail-view-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
+++ b/packages/extension-detail-view-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
@@ -38,6 +38,7 @@ export const createDefaultState = (): ExtensionDetailState => {
     initial: false,
     installationEntries: [],
     jsonValidation: [],
+    languages: [],
     lastUpdated: null,
     linkProtectionEnabled: false,
     locationHost: '',

--- a/packages/extension-detail-view-worker/src/parts/ExtensionDetailState/ExtensionDetailState.ts
+++ b/packages/extension-detail-view-worker/src/parts/ExtensionDetailState/ExtensionDetailState.ts
@@ -5,6 +5,7 @@ import type { ExtensionDetailButton } from '../GetExtensionDetailButtons/Extensi
 import type { MoreInfoEntry } from '../MoreInfoEntry/MoreInfoEntry.ts'
 import type { Resource } from '../Resource/Resource.ts'
 import type { Row } from '../Row/Row.ts'
+import type { SyntaxLanguage } from '../SyntaxLanguage/SyntaxLanguage.ts'
 import type { Tab } from '../Tab/Tab.ts'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import type { WebView } from '../WebView/WebView.ts'
@@ -46,6 +47,7 @@ export interface ExtensionDetailState {
   readonly initial: boolean
   readonly installationEntries: readonly MoreInfoEntry[]
   readonly jsonValidation: readonly Row[]
+  readonly languages: readonly SyntaxLanguage[]
   readonly lastUpdated: number | null
   readonly linkProtectionEnabled: boolean
   readonly locationHost: string

--- a/packages/extension-detail-view-worker/src/parts/GetSyntaxLanguages/GetSyntaxLanguages.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetSyntaxLanguages/GetSyntaxLanguages.ts
@@ -1,0 +1,40 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import type { SyntaxLanguage } from '../SyntaxLanguage/SyntaxLanguage.ts'
+
+const getStringArray = (value: unknown): readonly string[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+const toSyntaxLanguage = (value: unknown): SyntaxLanguage | undefined => {
+  if (!value || typeof value !== 'object') {
+    return undefined
+  }
+  const language = value as Record<string, unknown>
+  if (typeof language.id !== 'string' || typeof language.tokenize !== 'string') {
+    return undefined
+  }
+  return {
+    aliases: getStringArray(language.aliases),
+    extensions: getStringArray(language.extensions),
+    id: language.id,
+    tokenize: language.tokenize,
+  }
+}
+
+export const getSyntaxLanguages = async (platform: number, assetDir: string): Promise<readonly SyntaxLanguage[]> => {
+  try {
+    const languages = await ExtensionManagementWorker.getLanguages(platform, assetDir)
+    if (!Array.isArray(languages)) {
+      return []
+    }
+    return languages.flatMap((language) => {
+      const syntaxLanguage = toSyntaxLanguage(language)
+      return syntaxLanguage ? [syntaxLanguage] : []
+    })
+  } catch {
+    return []
+  }
+}

--- a/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
@@ -16,6 +16,7 @@ import { getExtensionIdFromUri } from '../GetExtensionIdFromUri/GetExtensionIdFr
 import { getLinkProtectionEnabled } from '../GetLinkProtectionEnabled/GetLinkProtectionEnabled.ts'
 import { getMarkdownVirtualDom } from '../GetMarkdownVirtualDom/GetMarkdownVirtualDom.ts'
 import { getPadding, getSideBarWidth } from '../GetPadding/GetPadding.ts'
+import { getSyntaxLanguages } from '../GetSyntaxLanguages/GetSyntaxLanguages.ts'
 import * as GetTabs from '../GetTabs/GetTabs.ts'
 import * as GetViewletSize from '../GetViewletSize/GetViewletSize.ts'
 import * as InputName from '../InputName/InputName.ts'
@@ -50,6 +51,7 @@ export const loadContent = async (
   }
   const currentColorThemeId = await getCurrentColorTheme()
   const commit = await getCommit()
+  const languages = await getSyntaxLanguages(platform, state.assetDir)
   const headerData: HeaderData = LoadHeaderContent.loadHeaderContent(state, platform, extension)
   const { badge, description, downloadCount, extensionId, extensionUri, extensionVersion, hasColorTheme, iconSrc, name, rating } = headerData
   const readmeUrl = Path.join(extensionUri, 'README.md')
@@ -64,6 +66,7 @@ export const loadContent = async (
   const readmeHtml = await RenderMarkdown.renderMarkdown(readmeContent, {
     baseUrl,
     commit,
+    languages,
     linksExternal: true,
     locationProtocol,
   })
@@ -125,6 +128,7 @@ export const loadContent = async (
     iconSrc,
     initial: false,
     installationEntries,
+    languages,
     lastUpdated,
     linkProtectionEnabled,
     locationHost,

--- a/packages/extension-detail-view-worker/src/parts/MarkdownOptions/MarkdownOptions.ts
+++ b/packages/extension-detail-view-worker/src/parts/MarkdownOptions/MarkdownOptions.ts
@@ -1,6 +1,9 @@
+import type { SyntaxLanguage } from '../SyntaxLanguage/SyntaxLanguage.ts'
+
 export interface MarkdownOptions {
   readonly baseUrl?: string
   readonly commit?: string
+  readonly languages?: readonly SyntaxLanguage[]
   readonly linksExternal?: boolean
   readonly locationProtocol: string
 }

--- a/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
+++ b/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
@@ -5,10 +5,11 @@ import * as LoadChangelogContent from '../LoadChangelogContent/LoadChangelogCont
 import * as RenderMarkdown from '../RenderMarkdown/RenderMarkdown.ts'
 
 export const selectTabChangelog = async (state: ExtensionDetailState): Promise<ExtensionDetailState> => {
-  const { baseUrl, extension, locationProtocol, tabs } = state
+  const { baseUrl, extension, languages, locationProtocol, tabs } = state
   const changelogContent = await LoadChangelogContent.loadChangelogContent(extension.path) // TODO use uri
   const changelogMarkdownHtml = await RenderMarkdown.renderMarkdown(changelogContent, {
     baseUrl,
+    languages,
     locationProtocol,
   })
   const changelogDom = await getMarkdownVirtualDom(changelogMarkdownHtml)

--- a/packages/extension-detail-view-worker/src/parts/SelectTabDetails/SelectTabDetails.ts
+++ b/packages/extension-detail-view-worker/src/parts/SelectTabDetails/SelectTabDetails.ts
@@ -5,10 +5,11 @@ import * as GetExtensionReadme from '../LoadReadmeContent/LoadReadmeContent.ts'
 import * as RenderMarkdown from '../RenderMarkdown/RenderMarkdown.ts'
 
 export const selectTabDetails = async (state: ExtensionDetailState): Promise<ExtensionDetailState> => {
-  const { baseUrl, locationProtocol, readmeUrl, tabs } = state
+  const { baseUrl, languages, locationProtocol, readmeUrl, tabs } = state
   const readmeContent = await GetExtensionReadme.loadReadmeContent(readmeUrl)
   const readmeHtml = await RenderMarkdown.renderMarkdown(readmeContent, {
     baseUrl,
+    languages,
     linksExternal: true,
     locationProtocol,
   })

--- a/packages/extension-detail-view-worker/src/parts/SyntaxLanguage/SyntaxLanguage.ts
+++ b/packages/extension-detail-view-worker/src/parts/SyntaxLanguage/SyntaxLanguage.ts
@@ -1,0 +1,6 @@
+export interface SyntaxLanguage {
+  readonly aliases?: readonly string[]
+  readonly extensions?: readonly string[]
+  readonly id: string
+  readonly tokenize: string
+}

--- a/packages/extension-detail-view-worker/test/GetSyntaxLanguages.test.ts
+++ b/packages/extension-detail-view-worker/test/GetSyntaxLanguages.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@jest/globals'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
+import { getSyntaxLanguages } from '../src/parts/GetSyntaxLanguages/GetSyntaxLanguages.ts'
+
+test('returns normalized extension-contributed languages', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getLanguages': () => [
+      {
+        aliases: ['JavaScript', 12],
+        extensions: ['.js', null],
+        id: 'javascript',
+        otherProperty: true,
+        tokenize: '/extensions/javascript/tokenize.js',
+      },
+      null,
+      { id: 42 },
+      { id: 'plaintext' },
+    ],
+  })
+
+  await expect(getSyntaxLanguages(1, '/assets')).resolves.toEqual([
+    {
+      aliases: ['JavaScript'],
+      extensions: ['.js'],
+      id: 'javascript',
+      tokenize: '/extensions/javascript/tokenize.js',
+    },
+  ])
+  expect(mockRpc.invocations).toEqual([['Extensions.getLanguages', 1, '/assets']])
+})
+
+test('returns empty languages for invalid response', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getLanguages': () => ({}),
+  })
+
+  await expect(getSyntaxLanguages(1, '/assets')).resolves.toEqual([])
+  expect(mockRpc.invocations).toHaveLength(1)
+})
+
+test('returns empty languages when extension management fails', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getLanguages': () => {
+      throw new Error('failed to load languages')
+    },
+  })
+
+  await expect(getSyntaxLanguages(1, '/assets')).resolves.toEqual([])
+  expect(mockRpc.invocations).toHaveLength(1)
+})

--- a/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
+++ b/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
@@ -7,7 +7,10 @@ import * as MarkdownWorker from '../src/parts/MarkdownWorker/MarkdownWorker.ts'
 import * as SelectTabChangelog from '../src/parts/SelectTabChangelog/SelectTabChangelog.ts'
 
 test('selectTabChangelog should update state with changelog content', async () => {
-  const state = createDefaultState.createDefaultState()
+  const state = {
+    ...createDefaultState.createDefaultState(),
+    languages: [{ extensions: ['.js'], id: 'javascript', tokenize: '/extensions/javascript/tokenize.js' }],
+  }
   const changelogContent = '# Changelog\n\n## Version 1.0.0\n- Initial release'
   const renderedHtml = '<h1>Changelog</h1><h2>Version 1.0.0</h2><ul><li>Initial release</li></ul>'
   const mockDom = [{ childCount: 1, type: VirtualDomElements.Div }]
@@ -35,7 +38,15 @@ test('selectTabChangelog should update state with changelog content', async () =
   expect(mockMarkdownRpc.invocations.length).toBeGreaterThan(0)
   expect(result.tabs.every((tab) => tab.selected === (tab.name === InputName.Changelog))).toBe(true)
   expect(mockMarkdownRpc.invocations).toEqual([
-    ['Markdown.render', expect.any(String), expect.any(Object)],
+    [
+      'Markdown.render',
+      changelogContent,
+      {
+        baseUrl: '',
+        languages: [{ extensions: ['.js'], id: 'javascript', tokenize: '/extensions/javascript/tokenize.js' }],
+        locationProtocol: '',
+      },
+    ],
     ['Markdown.getVirtualDom', expect.any(String)],
   ])
 })

--- a/packages/extension-detail-view-worker/test/SelectTabDetails.test.ts
+++ b/packages/extension-detail-view-worker/test/SelectTabDetails.test.ts
@@ -39,6 +39,7 @@ test('selectTabDetails sets selectedTab and detailsVirtualDom', async () => {
       path: '/test/path',
       version: '1.0.0',
     },
+    languages: [{ extensions: ['.js'], id: 'javascript', tokenize: '/extensions/javascript/tokenize.js' }],
     platform: 0,
   }
 
@@ -49,7 +50,16 @@ test('selectTabDetails sets selectedTab and detailsVirtualDom', async () => {
   expect(mockRendererRpc.invocations).toEqual([])
   expect(mockFileSystemRpc.invocations.length).toBeGreaterThan(0)
   expect(mockMarkdownRpc.invocations).toEqual([
-    ['Markdown.render', expect.any(String), expect.any(Object)],
+    [
+      'Markdown.render',
+      'README CONTENT',
+      {
+        baseUrl: '/test/baseUrl',
+        languages: [{ extensions: ['.js'], id: 'javascript', tokenize: '/extensions/javascript/tokenize.js' }],
+        linksExternal: true,
+        locationProtocol: '',
+      },
+    ],
     ['Markdown.getVirtualDom', expect.any(String)],
   ])
 })


### PR DESCRIPTION
Load tokenizable extension-contributed languages for extension details and pass them through README and changelog markdown rendering. Add focused coverage plus a deferred browser regression for highlighted fenced code blocks.