### PR TITLE
fix: hide marketplace for builtin extensions

### DIFF
--- a/packages/e2e/fixtures/extension-builtin/README.md
+++ b/packages/e2e/fixtures/extension-builtin/README.md
@@ -1,0 +1,1 @@
+# Test builtin extension

--- a/packages/e2e/fixtures/extension-builtin/extension.json
+++ b/packages/e2e/fixtures/extension-builtin/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "test.extension-builtin",
+  "name": "Test Builtin Extension",
+  "description": "Test Builtin Extension Description",
+  "builtin": true,
+  "categories": ["Themes"]
+}

--- a/packages/e2e/src/extension-detail.builtin-marketplace-hidden.ts
+++ b/packages/e2e/src/extension-detail.builtin-marketplace-hidden.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-builtin')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-builtin')
+
+  // assert
+  const headings = Locator('.AdditionalDetailsTitle')
+  await expect(headings).toHaveCount(3)
+  const installationHeading = headings.nth(0)
+  await expect(installationHeading).toHaveText('Installation')
+  const categoriesHeading = headings.nth(1)
+  await expect(categoriesHeading).toHaveText('Categories')
+  const resourcesHeading = headings.nth(2)
+  await expect(resourcesHeading).toHaveText('Resources')
+}

--- a/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
@@ -73,7 +73,7 @@ export const loadContent = async (
   const detailsVirtualDom = await getMarkdownVirtualDom(readmeHtml, {
     scrollToTopEnabled: true,
   })
-  const isBuiltin = extension?.isBuiltin
+  const isBuiltin = extension?.isBuiltin || extension?.builtin || false
   const disabled = extension?.disabled
   const extensionColorThemeId = getColorThemeId(extension) || ''
   const extensionColorThemeLabel = getColorThemeLabel(extension) || ''

--- a/packages/extension-detail-view-worker/test/LoadContent.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadContent.test.ts
@@ -168,8 +168,8 @@ test('loadContent - with builtin extension', async () => {
 
   const result: ExtensionDetailState = await LoadContent.loadContent(state, 1, {})
 
-  // expect(result.isBuiltin).toBe(true)
   expect(result.extension).toEqual(mockExtension)
+  expect(result.marketplaceEntries).toEqual([])
   expect(mockRendererRpc.invocations).toEqual([
     ['ExtensionManagement.getExtension', 'builtin-extension'],
     ['Preferences.get', 'workbench.colorTheme'],


### PR DESCRIPTION
Built-in extension metadata uses the `builtin` field, so normalize that field when loading detail content. This hides the Marketplace section and other install-only actions for built-in extensions, with focused unit and e2e regression coverage.