### PR TITLE
fix: display web extension detail icons

### DIFF
--- a/packages/e2e/fixtures/extension-basics/extension.json
+++ b/packages/e2e/fixtures/extension-basics/extension.json
@@ -2,6 +2,7 @@
   "id": "test.extension-basics",
   "name": "Test",
   "description": "Test Description",
+  "icon": "icon.svg",
   "commands": [
     {
       "id": "test",

--- a/packages/e2e/fixtures/extension-basics/icon.svg
+++ b/packages/e2e/fixtures/extension-basics/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#193549" />
+  <path d="M16 32h32M32 16v32" stroke="#ffc600" stroke-width="8" />
+</svg>

--- a/packages/e2e/src/extension-detail.basics.ts
+++ b/packages/e2e/src/extension-detail.basics.ts
@@ -13,6 +13,7 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await expect(detailView).toBeVisible()
   const icon = Locator('.ExtensionDetailIcon')
   await expect(icon).toBeVisible()
+  await expect(icon).toHaveAttribute('src', `${extensionUri}/icon.svg`)
   const name = Locator('.ExtensionDetailName')
   await expect(name).toBeVisible()
   await expect(name).toHaveText('Test')

--- a/packages/e2e/src/extension-detail.basics.ts
+++ b/packages/e2e/src/extension-detail.basics.ts
@@ -13,7 +13,7 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await expect(detailView).toBeVisible()
   const icon = Locator('.ExtensionDetailIcon')
   await expect(icon).toBeVisible()
-  await expect(icon).toHaveAttribute('src', `${extensionUri}/icon.svg`)
+  await expect(icon).toHaveAttribute('src', `/remote/${extensionUri}/icon.svg`)
   const name = Locator('.ExtensionDetailName')
   await expect(name).toBeVisible()
   await expect(name).toHaveText('Test')

--- a/packages/extension-detail-view-worker/src/parts/GetIcon/GetIcon.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetIcon/GetIcon.ts
@@ -22,5 +22,8 @@ export const getIcon = (extension: any, platform: number, assetDir: string): str
     }
     return `/remote/${extension.path}/${extension.icon}` // TODO support windows paths
   }
+  if (platform === PlatformType.Web) {
+    return `${extension.path}/${extension.icon}`
+  }
   return ''
 }

--- a/packages/extension-detail-view-worker/test/ExtensionDisplay.test.ts
+++ b/packages/extension-detail-view-worker/test/ExtensionDisplay.test.ts
@@ -49,10 +49,10 @@ test('getIcon returns asset path for builtin extension', () => {
   expect(ExtensionDisplay.getIcon(extension, PlatformType.Remote, '')).toBe('/extensions/test-ext/icon.png')
 })
 
-test('getIcon returns empty string for web platform', () => {
+test('getIcon returns extension icon path for web platform', () => {
   const extension = {
     icon: 'icon.png',
     path: 'test/path',
   }
-  expect(ExtensionDisplay.getIcon(extension, PlatformType.Web, '')).toBe('')
+  expect(ExtensionDisplay.getIcon(extension, PlatformType.Web, '')).toBe('test/path/icon.png')
 })

--- a/packages/extension-detail-view-worker/test/GetIcon.test.ts
+++ b/packages/extension-detail-view-worker/test/GetIcon.test.ts
@@ -65,14 +65,15 @@ test('getIcon returns remote path for Remote platform', () => {
   expect(result).toBe(`${assetDir}/extensions/test.extension/icon.png`)
 })
 
-test('getIcon returns empty string for Web platform with path and icon', () => {
+test('getIcon returns extension icon path for Web platform', () => {
   const extension = {
+    builtin: true,
     icon: 'icon.png',
     id: 'test.extension',
     path: '/path/to/extension',
   }
   const result = getIcon(extension, PlatformType.Web, assetDir)
-  expect(result).toBe('')
+  expect(result).toBe('/path/to/extension/icon.png')
 })
 
 test('getIcon prefers language basics over theme when both conditions match', () => {


### PR DESCRIPTION
Fix web extension detail headers to resolve custom icons from the extension path, matching the extension search view. Adds unit and browser regression coverage for the rendered icon URL.