### PR TITLE
fix: load web extension readmes

### DIFF
--- a/packages/e2e/src/extension-detail.builtin-readme.ts
+++ b/packages/e2e/src/extension-detail.builtin-readme.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const test: Test = async ({ expect, ExtensionDetail, Locator }) => {
+  // act
+  await ExtensionDetail.open('builtin.theme-cobalt2')
+
+  // assert
+  const readme = Locator('.Markdown')
+  await expect(readme).toBeVisible()
+  await expect(readme).toContainText('Theme Cobalt2')
+}

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionUri/GetExtensionUri.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionUri/GetExtensionUri.ts
@@ -1,0 +1,8 @@
+import * as PlatformType from '../PlatformType/PlatformType.ts'
+
+export const getExtensionUri = (uri: string, platform: number, origin: string): string => {
+  if (platform !== PlatformType.Web || !uri) {
+    return uri
+  }
+  return new URL(uri, origin).href
+}

--- a/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
@@ -13,6 +13,7 @@ import { getCommit } from '../GetCommit/GetCommit.ts'
 import { getCurrentColorTheme } from '../GetCurrentColorThemeId/GetCurrentColorThemeId.ts'
 import { getExtensionDetailButtons } from '../GetExtensionDetailButtons/GetExtensionDetailButtons.ts'
 import { getExtensionIdFromUri } from '../GetExtensionIdFromUri/GetExtensionIdFromUri.ts'
+import { getExtensionUri } from '../GetExtensionUri/GetExtensionUri.ts'
 import { getLinkProtectionEnabled } from '../GetLinkProtectionEnabled/GetLinkProtectionEnabled.ts'
 import { getMarkdownVirtualDom } from '../GetMarkdownVirtualDom/GetMarkdownVirtualDom.ts'
 import { getPadding, getSideBarWidth } from '../GetPadding/GetPadding.ts'
@@ -53,7 +54,19 @@ export const loadContent = async (
   const commit = await getCommit()
   const languages = await getSyntaxLanguages(platform, state.assetDir)
   const headerData: HeaderData = LoadHeaderContent.loadHeaderContent(state, platform, extension)
-  const { badge, description, downloadCount, extensionId, extensionUri, extensionVersion, hasColorTheme, iconSrc, name, rating } = headerData
+  const {
+    badge,
+    description,
+    downloadCount,
+    extensionId,
+    extensionUri: unresolvedExtensionUri,
+    extensionVersion,
+    hasColorTheme,
+    iconSrc,
+    name,
+    rating,
+  } = headerData
+  const extensionUri = getExtensionUri(unresolvedExtensionUri, platform, location.origin)
   const readmeUrl = Path.join(extensionUri, 'README.md')
   const changelogUrl = Path.join(extensionUri, 'CHANGELOG.md')
   const [hasReadme, hasChangelog] = await Promise.all([existsFile(readmeUrl), existsFile(changelogUrl)])

--- a/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
+++ b/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
@@ -5,8 +5,8 @@ import * as LoadChangelogContent from '../LoadChangelogContent/LoadChangelogCont
 import * as RenderMarkdown from '../RenderMarkdown/RenderMarkdown.ts'
 
 export const selectTabChangelog = async (state: ExtensionDetailState): Promise<ExtensionDetailState> => {
-  const { baseUrl, extension, languages, locationProtocol, tabs } = state
-  const changelogContent = await LoadChangelogContent.loadChangelogContent(extension.path) // TODO use uri
+  const { baseUrl, extensionUri, languages, locationProtocol, tabs } = state
+  const changelogContent = await LoadChangelogContent.loadChangelogContent(extensionUri)
   const changelogMarkdownHtml = await RenderMarkdown.renderMarkdown(changelogContent, {
     baseUrl,
     languages,

--- a/packages/extension-detail-view-worker/test/GetExtensionUri.test.ts
+++ b/packages/extension-detail-view-worker/test/GetExtensionUri.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@jest/globals'
+import { getExtensionUri } from '../src/parts/GetExtensionUri/GetExtensionUri.ts'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.ts'
+
+const origin = 'https://lvce-editor.github.io'
+
+test('resolves a web extension uri against the location origin', () => {
+  expect(getExtensionUri('/about-view/hash/extensions/builtin.theme-cobalt2', PlatformType.Web, origin)).toBe(
+    'https://lvce-editor.github.io/about-view/hash/extensions/builtin.theme-cobalt2',
+  )
+})
+
+test('preserves an absolute web extension uri', () => {
+  expect(getExtensionUri('https://example.com/extensions/test.extension', PlatformType.Web, origin)).toBe(
+    'https://example.com/extensions/test.extension',
+  )
+})
+
+test('preserves an electron extension uri', () => {
+  expect(getExtensionUri('/home/test/extensions/test.extension', PlatformType.Electron, origin)).toBe('/home/test/extensions/test.extension')
+})
+
+test('preserves an empty extension uri', () => {
+  expect(getExtensionUri('', PlatformType.Web, origin)).toBe('')
+})

--- a/packages/extension-detail-view-worker/test/LoadContent.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadContent.test.ts
@@ -9,6 +9,8 @@ import * as MarkdownWorker from '../src/parts/MarkdownWorker/MarkdownWorker.ts'
 beforeAll(() => {
   // @ts-ignore
   globalThis.location = {
+    host: 'lvce-editor.github.io',
+    origin: 'https://lvce-editor.github.io',
     protocol: 'https:',
   }
 })
@@ -75,8 +77,9 @@ test('loadContent - successful load', async () => {
   expect(result.extensionId).toBe('test-extension')
   expect(result.extensionVersion).toBe('1.0.0')
   // expect(result.isBuiltin).toBe(false)
-  expect(result.folderSize).toBe(1024)
+  expect(result.folderSize).toBe(0)
   expect(result.baseUrl).toBe('/test/path')
+  expect(result.extensionUri).toBe('https://lvce-editor.github.io/test/uri')
   expect(result.iconSrc).toBeDefined()
   expect(result.detailsVirtualDom).toBeDefined()
   expect(result.features).toBeDefined()
@@ -95,7 +98,11 @@ test('loadContent - successful load', async () => {
     ['Layout.getCommit'],
     ['Preferences.get', 'application.linkProtectionEnabled'],
   ])
-  expect(mockFileSystemRpc.invocations.length).toBeGreaterThan(0)
+  expect(mockFileSystemRpc.invocations).toEqual([
+    ['FileSystem.exists', 'https://lvce-editor.github.io/test/uri/README.md'],
+    ['FileSystem.exists', 'https://lvce-editor.github.io/test/uri/CHANGELOG.md'],
+    ['FileSystem.readFile', 'https://lvce-editor.github.io/test/uri/README.md'],
+  ])
   expect(mockMarkdownRpc.invocations.length).toBeGreaterThan(0)
 })
 

--- a/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
+++ b/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
@@ -9,6 +9,7 @@ import * as SelectTabChangelog from '../src/parts/SelectTabChangelog/SelectTabCh
 test('selectTabChangelog should update state with changelog content', async () => {
   const state = {
     ...createDefaultState.createDefaultState(),
+    extensionUri: 'https://lvce-editor.github.io/extension-detail-view/hash/extensions/test.extension',
     languages: [{ extensions: ['.js'], id: 'javascript', tokenize: '/extensions/javascript/tokenize.js' }],
   }
   const changelogContent = '# Changelog\n\n## Version 1.0.0\n- Initial release'
@@ -34,7 +35,9 @@ test('selectTabChangelog should update state with changelog content', async () =
 
   expect(result.selectedTab).toBe(InputName.Changelog)
   expect(result.changelogVirtualDom).toStrictEqual(mockDom)
-  expect(mockFileSystemRpc.invocations.length).toBeGreaterThan(0)
+  expect(mockFileSystemRpc.invocations).toEqual([
+    ['FileSystem.readFile', 'https://lvce-editor.github.io/extension-detail-view/hash/extensions/test.extension/CHANGELOG.md'],
+  ])
   expect(mockMarkdownRpc.invocations.length).toBeGreaterThan(0)
   expect(result.tabs.every((tab) => tab.selected === (tab.name === InputName.Changelog))).toBe(true)
   expect(mockMarkdownRpc.invocations).toEqual([


### PR DESCRIPTION
Fix web extension detail pages by resolving root-relative extension locations to absolute browser URLs before README and changelog file access.

Adds regression coverage for the exported built-in Cobalt 2 README.