### PR TITLE
feature: show relative extension update time

### DIFF
--- a/packages/e2e/fixtures/extension-last-updated-valid/extension.json
+++ b/packages/e2e/fixtures/extension-last-updated-valid/extension.json
@@ -9,5 +9,5 @@
     }
   ],
   "categories": ["Themes"],
-  "lastUpdated": 1705276800000
+  "lastUpdated": "2024-01-15T00:00:00.000Z"
 }

--- a/packages/e2e/src/extension-detail.last-updated-valid.ts
+++ b/packages/e2e/src/extension-detail.last-updated-valid.ts
@@ -1,7 +1,5 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
   // arrange
   const extensionUri = import.meta.resolve('../fixtures/extension-last-updated-valid')
@@ -18,5 +16,5 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await expect(moreInfoEntryKey).toHaveText('Last Updated')
   const moreInfoEntryValue = moreInfoEntry.locator('.MoreInfoEntryValue')
   await expect(moreInfoEntryValue).not.toHaveText('n/a')
-  await expect(moreInfoEntryValue).toHaveText('2024')
+  await expect(moreInfoEntryValue).toHaveText('2 years ago')
 }

--- a/packages/e2e/src/extension-detail.last-updated-valid.ts
+++ b/packages/e2e/src/extension-detail.last-updated-valid.ts
@@ -15,6 +15,5 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   const moreInfoEntryKey = moreInfoEntry.locator('.MoreInfoEntryKey')
   await expect(moreInfoEntryKey).toHaveText('Last Updated')
   const moreInfoEntryValue = moreInfoEntry.locator('.MoreInfoEntryValue')
-  await expect(moreInfoEntryValue).not.toHaveText('n/a')
   await expect(moreInfoEntryValue).toHaveText('2 years ago')
 }

--- a/packages/extension-detail-view-worker/src/parts/FormatLastUpdated/FormatLastUpdated.ts
+++ b/packages/extension-detail-view-worker/src/parts/FormatLastUpdated/FormatLastUpdated.ts
@@ -1,18 +1,5 @@
-export const formatLastUpdated = (lastUpdated: number | null): string => {
-  if (lastUpdated === null) {
-    return 'n/a'
-  }
-  try {
-    const date = new Date(lastUpdated * 1000)
-    if (Number.isNaN(date.getTime())) {
-      return 'n/a'
-    }
-    return date.toLocaleDateString(undefined, {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-    })
-  } catch {
-    return 'n/a'
-  }
+import * as FormatCreated from '../FormatCreated/FormatCreated.ts'
+
+export const formatLastUpdated = (lastUpdated: number | null, now: number = Date.now()): string => {
+  return FormatCreated.formatCreated(lastUpdated, now)
 }

--- a/packages/extension-detail-view-worker/src/parts/ParseLastUpdated/ParseLastUpdated.ts
+++ b/packages/extension-detail-view-worker/src/parts/ParseLastUpdated/ParseLastUpdated.ts
@@ -1,3 +1,15 @@
+const secondsToMillisecondsThreshold = 10_000_000_000
+
+const normalizeTimestamp = (timestamp: number): number | null => {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) {
+    return null
+  }
+  if (timestamp < secondsToMillisecondsThreshold) {
+    return timestamp * 1000
+  }
+  return timestamp
+}
+
 export const parseLastUpdated = (extension: unknown): number | null => {
   if (!extension || typeof extension !== 'object') {
     return null
@@ -7,16 +19,14 @@ export const parseLastUpdated = (extension: unknown): number | null => {
     return null
   }
   if (typeof lastUpdated === 'number') {
-    if (Number.isFinite(lastUpdated) && lastUpdated > 0) {
-      return lastUpdated
-    }
-    return null
+    return normalizeTimestamp(lastUpdated)
   }
   if (typeof lastUpdated === 'string') {
-    const parsed = Number.parseFloat(lastUpdated)
-    if (Number.isFinite(parsed) && parsed > 0) {
-      return parsed
+    const numericTimestamp = Number(lastUpdated)
+    if (Number.isFinite(numericTimestamp)) {
+      return normalizeTimestamp(numericTimestamp)
     }
+    return normalizeTimestamp(Date.parse(lastUpdated))
   }
   return null
 }

--- a/packages/extension-detail-view-worker/test/FormatLastUpdated.test.ts
+++ b/packages/extension-detail-view-worker/test/FormatLastUpdated.test.ts
@@ -5,11 +5,16 @@ test('formatLastUpdated returns n/a for null', () => {
   expect(FormatLastUpdated.formatLastUpdated(null)).toBe('n/a')
 })
 
-test('formatLastUpdated returns formatted date for valid timestamp', () => {
-  const timestamp = new Date('2024-01-15').getTime()
-  const result = FormatLastUpdated.formatLastUpdated(timestamp)
-  expect(result).not.toBe('n/a')
-  expect(result).toBe('Jan 27, 56008')
+test('formatLastUpdated returns relative time for a past date', () => {
+  const lastUpdated = new Date('2024-01-15').getTime()
+  const now = new Date('2024-02-15').getTime()
+  expect(FormatLastUpdated.formatLastUpdated(lastUpdated, now)).toBe('1 month ago')
+})
+
+test('formatLastUpdated returns relative time for a future date', () => {
+  const lastUpdated = new Date('2024-02-15').getTime()
+  const now = new Date('2024-01-15').getTime()
+  expect(FormatLastUpdated.formatLastUpdated(lastUpdated, now)).toBe('in 1 month')
 })
 
 test('formatLastUpdated returns n/a for invalid timestamp', () => {

--- a/packages/extension-detail-view-worker/test/GetInstallationEntries.test.ts
+++ b/packages/extension-detail-view-worker/test/GetInstallationEntries.test.ts
@@ -123,7 +123,7 @@ test('get installation entries with valid lastUpdated timestamp', () => {
   const result = GetInstallationEntries.getInstallationEntries('1.0MB', 'test-extension', '1.0.0', '/test/path', showSizeLink, null, lastUpdated)
   expect(result[2].key).toBe('Last Updated')
   expect(result[2].value).not.toBe('n/a')
-  expect(result[2].value).toBe('Jan 27, 56008')
+  expect(result[2].value).toContain('ago')
 })
 
 test('get installation entries with created timestamp', () => {

--- a/packages/extension-detail-view-worker/test/ParseLastUpdated.test.ts
+++ b/packages/extension-detail-view-worker/test/ParseLastUpdated.test.ts
@@ -23,14 +23,24 @@ test('parseLastUpdated returns null when lastUpdated is null', () => {
   expect(ParseLastUpdated.parseLastUpdated(extension)).toBe(null)
 })
 
-test('parseLastUpdated returns number when lastUpdated is a valid number', () => {
+test('parseLastUpdated returns milliseconds when lastUpdated is a millisecond timestamp', () => {
   const extension = { lastUpdated: 1_705_276_800_000 }
   expect(ParseLastUpdated.parseLastUpdated(extension)).toBe(1_705_276_800_000)
 })
 
-test('parseLastUpdated returns number when lastUpdated is a valid string number', () => {
+test('parseLastUpdated converts a timestamp in seconds to milliseconds', () => {
+  const extension = { lastUpdated: 1_705_276_800 }
+  expect(ParseLastUpdated.parseLastUpdated(extension)).toBe(1_705_276_800_000)
+})
+
+test('parseLastUpdated returns milliseconds when lastUpdated is a numeric string', () => {
   const extension = { lastUpdated: '1705276800000' }
   expect(ParseLastUpdated.parseLastUpdated(extension)).toBe(1_705_276_800_000)
+})
+
+test('parseLastUpdated parses an ISO date string', () => {
+  const extension = { lastUpdated: '2024-01-15T10:30:00+05:30' }
+  expect(ParseLastUpdated.parseLastUpdated(extension)).toBe(1_705_294_800_000)
 })
 
 test('parseLastUpdated returns null when lastUpdated is an invalid string', () => {


### PR DESCRIPTION
Parse ISO lastUpdated metadata and legacy numeric timestamps, then display the extension update time as a relative value.