### PR TITLE
fix: suppress extension detail header context menu

### DIFF
--- a/packages/extension-detail-view-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/extension-detail-view-worker/src/parts/CommandMap/CommandMap.ts
@@ -27,6 +27,7 @@ import * as HandleClickSize from '../HandleClickSize/HandleClickSize.ts'
 import * as HandleClickUninstall from '../HandleClickUninstall/HandleClickUninstall.ts'
 import { handleExtensionsChanged } from '../HandleExtensionsChanged/HandleExtensionsChanged.ts'
 import * as HandleExtensionsStatusUpdate from '../HandleExtensionsStatusUpdate/HandleExtensionsStatusUpdate.ts'
+import { handleHeaderContextMenu } from '../HandleHeaderContextMenu/HandleHeaderContextMenu.ts'
 import * as HandleIconError from '../HandleIconError/HandleIconError.ts'
 import { handleImageContextMenu } from '../HandleImageContextMenu/HandleImageContextMenu.ts'
 import * as HandleMouseEnterEnable from '../HandleMouseEnterEnable/HandleMouseEnterEnable.ts'
@@ -76,6 +77,7 @@ export const commandMap = {
   'ExtensionDetail.handleExtensionsChanged': WrapCommand.wrapCommand(handleExtensionsChanged),
   'ExtensionDetail.handleExtensionsStatusUpdate': WrapCommand.wrapCommand(HandleExtensionsStatusUpdate.handleExtensionsStatusUpdate),
   'ExtensionDetail.handleFeaturesClick': WrapCommand.wrapCommand(HandleClickFeatures.handleClickFeatures),
+  'ExtensionDetail.handleHeaderContextMenu': WrapCommand.wrapCommand(handleHeaderContextMenu),
   'ExtensionDetail.handleIconError': WrapCommand.wrapCommand(HandleIconError.handleIconError),
   'ExtensionDetail.handleImageContextMenu': WrapCommand.wrapCommand(handleImageContextMenu),
   'ExtensionDetail.handleMouseEnterEnable': WrapCommand.wrapCommand(HandleMouseEnterEnable.handleMouseEnterEnable),

--- a/packages/extension-detail-view-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
+++ b/packages/extension-detail-view-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
@@ -19,3 +19,4 @@ export const HandleTabFocus = 18
 export const HandleResourceLinkClick = 19
 export const HandleMouseEnterEnable = 20
 export const HandleMouseLeaveEnable = 21
+export const HandleHeaderContextMenu = 22

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailHeaderVirtualDom/GetExtensionDetailHeaderVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailHeaderVirtualDom/GetExtensionDetailHeaderVirtualDom.ts
@@ -2,6 +2,7 @@ import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { ExtensionDetailButton } from '../GetExtensionDetailButtons/ExtensionDetailButton.ts'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import { getExtensionDetailDescriptionVirtualDom } from '../GetExtensionDetailDescriptionVirtualDom/GetExtensionDetailDescriptionVirtualDom.ts'
 import * as GetExtensionDetailHeaderActionsVirtualDom from '../GetExtensionDetailHeaderActionsVirtualDom/GetExtensionDetailHeaderActionsVirtualDom.ts'
 import { getExtensionDetailIconVirtualDom } from '../GetExtensionDetailIconVirtualDom/GetExtensionDetailIconVirtualDom.ts'
@@ -25,6 +26,7 @@ export const getExtensionDetailHeaderVirtualDom = (
     {
       childCount: 3,
       className: ClassNames.ExtensionDetailHeaderDetails,
+      onContextMenu: DomEventListenerFunctions.HandleHeaderContextMenu,
       type: VirtualDomElements.Div,
     },
     ...getExtensionDetailNameVirtualDom(name, badge),

--- a/packages/extension-detail-view-worker/src/parts/HandleHeaderContextMenu/HandleHeaderContextMenu.ts
+++ b/packages/extension-detail-view-worker/src/parts/HandleHeaderContextMenu/HandleHeaderContextMenu.ts
@@ -1,0 +1,5 @@
+import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
+
+export const handleHeaderContextMenu = async (state: ExtensionDetailState): Promise<ExtensionDetailState> => {
+  return state
+}

--- a/packages/extension-detail-view-worker/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/extension-detail-view-worker/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -34,6 +34,11 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
       preventDefault: true,
     },
     {
+      name: DomEventListenerFunctions.HandleHeaderContextMenu,
+      params: ['handleHeaderContextMenu'],
+      preventDefault: true,
+    },
+    {
       name: DomEventListenerFunctions.HandleReadmeScroll,
       params: ['handleScroll', 'event.target.scrollTop', InputSource.User],
       passive: true,

--- a/packages/extension-detail-view-worker/test/GetExtensionDetailHeaderVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetExtensionDetailHeaderVirtualDom.test.ts
@@ -1,11 +1,23 @@
 import { expect, test } from '@jest/globals'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import * as ClassNames from '../src/parts/ClassNames/ClassNames.ts'
+import * as DomEventListenerFunctions from '../src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as ExtensionDetailStrings from '../src/parts/ExtensionDetailStrings/ExtensionDetailStrings.ts'
 import * as GetExtensionDetailButtons from '../src/parts/GetExtensionDetailButtons/GetExtensionDetailButtons.ts'
 import * as GetExtensionDetailHeaderVirtualDom from '../src/parts/GetExtensionDetailHeaderVirtualDom/GetExtensionDetailHeaderVirtualDom.ts'
 import * as InputName from '../src/parts/InputName/InputName.ts'
 import { text } from '../src/parts/VirtualDomHelpers/VirtualDomHelpers.ts'
+
+test('adds a context menu listener to the extension detail header details', () => {
+  const result = GetExtensionDetailHeaderVirtualDom.getExtensionDetailHeaderVirtualDom('name', 'icon.png', 'description', '', [], false)
+
+  expect(result[2]).toEqual({
+    childCount: 3,
+    className: ClassNames.ExtensionDetailHeaderDetails,
+    onContextMenu: DomEventListenerFunctions.HandleHeaderContextMenu,
+    type: VirtualDomElements.Div,
+  })
+})
 
 test.skip('extension detail header virtual dom', () => {
   const extensionDetail = {

--- a/packages/extension-detail-view-worker/test/HandleHeaderContextMenu.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleHeaderContextMenu.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@jest/globals'
+import * as CreateDefaultState from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleHeaderContextMenu } from '../src/parts/HandleHeaderContextMenu/HandleHeaderContextMenu.ts'
+
+test('handleHeaderContextMenu returns the same state', async () => {
+  const state = CreateDefaultState.createDefaultState()
+
+  const result = await handleHeaderContextMenu(state)
+
+  expect(result).toBe(state)
+})

--- a/packages/extension-detail-view-worker/test/RenderEventListeners.test.ts
+++ b/packages/extension-detail-view-worker/test/RenderEventListeners.test.ts
@@ -13,4 +13,9 @@ test('renderEventListeners returns expected event listeners', () => {
     name: DomEventListenerFunctions.HandleMouseLeaveEnable,
     params: ['handleMouseLeaveEnable'],
   })
+  expect(result).toContainEqual({
+    name: DomEventListenerFunctions.HandleHeaderContextMenu,
+    params: ['handleHeaderContextMenu'],
+    preventDefault: true,
+  })
 })


### PR DESCRIPTION
Suppresses the native browser context menu in the extension detail header area while leaving the extension icon's custom context menu unchanged.