### PR TITLE
fix: limit extreme changelog rendering

### DIFF
--- a/packages/e2e/src/extension-detail.changelog-github-5000-releases.ts
+++ b/packages/e2e/src/extension-detail.changelog-github-5000-releases.ts
@@ -3,7 +3,8 @@ import { openGithubChangelog } from './_GithubReleaseTest.js'
 
 export const test: Test = async (api) => {
   await openGithubChangelog(api, { releaseCount: 5000, type: 'generated' })
-  await api.expect(api.Locator('.Changelog h1')).toHaveCount(5000)
+  await api.expect(api.Locator('.Changelog h1')).toHaveCount(1000)
+  await api.expect(api.Locator('.Changelog')).toContainText('Showing the newest 1000 of 5000 GitHub releases')
   await api.expect(api.Locator('.Changelog')).toContainText('Version 5000')
-  await api.expect(api.Locator('.Changelog')).toContainText('Version 1')
+  await api.expect(api.Locator('.Changelog')).toContainText('Version 4001')
 }

--- a/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
+++ b/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
@@ -10,6 +10,7 @@ import { loadGithubReleases } from '../LoadGithubReleases/LoadGithubReleases.ts'
 import * as RenderMarkdown from '../RenderMarkdown/RenderMarkdown.ts'
 
 const releaseBatchSize = 250
+const maximumDisplayedReleases = 1000
 
 const mergeMarkdownVirtualDoms = (chunks: readonly (readonly VirtualDomNode[])[]): readonly VirtualDomNode[] => {
   let root: VirtualDomNode | undefined
@@ -32,15 +33,20 @@ const renderGithubReleases = async (
   locationProtocol: string,
 ): Promise<readonly VirtualDomNode[]> => {
   const chunks: VirtualDomNode[][] = []
+  const displayedReleases = releases.slice(0, maximumDisplayedReleases)
   const releaseGroups =
-    releases.length === 0
+    displayedReleases.length === 0
       ? [[]]
-      : Array.from({ length: Math.ceil(releases.length / releaseBatchSize) }, (_, index) => {
-          return releases.slice(index * releaseBatchSize, (index + 1) * releaseBatchSize)
+      : Array.from({ length: Math.ceil(displayedReleases.length / releaseBatchSize) }, (_, index) => {
+          return displayedReleases.slice(index * releaseBatchSize, (index + 1) * releaseBatchSize)
         })
   const baseUrl = `https://github.com/${githubRepository.owner}/${githubRepository.repository}/blob/HEAD/`
-  for (const releaseGroup of releaseGroups) {
-    const markdown = getGithubReleasesMarkdown(releaseGroup, githubRepository)
+  for (const [index, releaseGroup] of releaseGroups.entries()) {
+    const limitMessage =
+      index === 0 && releases.length > displayedReleases.length
+        ? `> Showing the newest ${displayedReleases.length} of ${releases.length} GitHub releases. Older releases are not displayed to keep the editor responsive.\n\n`
+        : ''
+    const markdown = limitMessage + getGithubReleasesMarkdown(releaseGroup, githubRepository)
     const html = await RenderMarkdown.renderMarkdown(markdown, { baseUrl, languages, linksExternal: true, locationProtocol })
     chunks.push([...(await getMarkdownVirtualDom(html))])
   }

--- a/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
+++ b/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
@@ -105,7 +105,7 @@ test('selectTabChangelog renders a friendly GitHub error', async () => {
   expect(mockMarkdownRpc.invocations[0]).toEqual(['Markdown.render', expect.stringContaining('GitHub is not reachable'), expect.any(Object)])
 })
 
-test('selectTabChangelog renders 5000 GitHub releases in safe batches', async () => {
+test('selectTabChangelog handles 5000 GitHub releases with a responsive display limit', async () => {
   GithubApiRequest.mockGithubApi({ releaseCount: 5000, type: 'generated' })
   using mockMarkdownRpc = MarkdownWorker.registerMockRpc({
     'Markdown.getVirtualDom': () => [{ childCount: 1, type: VirtualDomElements.Div }],
@@ -119,7 +119,8 @@ test('selectTabChangelog renders 5000 GitHub releases in safe batches', async ()
   await SelectTabChangelog.selectTabChangelog(state)
 
   const renderInvocations = mockMarkdownRpc.invocations.filter(([command]) => command === 'Markdown.render')
-  expect(renderInvocations).toHaveLength(20)
+  expect(renderInvocations).toHaveLength(4)
+  expect(renderInvocations[0][1]).toContain('Showing the newest 1000 of 5000 GitHub releases')
   expect(renderInvocations[0][1]).toContain('Version 5000')
-  expect(renderInvocations.at(-1)?.[1]).toContain('Version 1')
+  expect(renderInvocations.at(-1)?.[1]).toContain('Version 4001')
 })


### PR DESCRIPTION
Keeps very large GitHub changelogs responsive by rendering the newest 1,000 releases with an explicit limit notice. This preserves the 5,000-release API edge case without crashing Chromium on Windows.