### PR TITLE
fix: reduce extreme changelog display limit

### DIFF
--- a/packages/e2e/src/extension-detail.changelog-github-5000-releases.ts
+++ b/packages/e2e/src/extension-detail.changelog-github-5000-releases.ts
@@ -3,8 +3,8 @@ import { openGithubChangelog } from './_GithubReleaseTest.js'
 
 export const test: Test = async (api) => {
   await openGithubChangelog(api, { releaseCount: 5000, type: 'generated' })
-  await api.expect(api.Locator('.Changelog h1')).toHaveCount(1000)
-  await api.expect(api.Locator('.Changelog')).toContainText('Showing the newest 1000 of 5000 GitHub releases')
+  await api.expect(api.Locator('.Changelog h1')).toHaveCount(250)
+  await api.expect(api.Locator('.Changelog')).toContainText('Showing the newest 250 of 5000 GitHub releases')
   await api.expect(api.Locator('.Changelog')).toContainText('Version 5000')
-  await api.expect(api.Locator('.Changelog')).toContainText('Version 4001')
+  await api.expect(api.Locator('.Changelog')).toContainText('Version 4751')
 }

--- a/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
+++ b/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
@@ -10,7 +10,7 @@ import { loadGithubReleases } from '../LoadGithubReleases/LoadGithubReleases.ts'
 import * as RenderMarkdown from '../RenderMarkdown/RenderMarkdown.ts'
 
 const releaseBatchSize = 250
-const maximumDisplayedReleases = 1000
+const maximumDisplayedReleases = 250
 
 const mergeMarkdownVirtualDoms = (chunks: readonly (readonly VirtualDomNode[])[]): readonly VirtualDomNode[] => {
   let root: VirtualDomNode | undefined

--- a/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
+++ b/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
@@ -119,8 +119,8 @@ test('selectTabChangelog handles 5000 GitHub releases with a responsive display 
   await SelectTabChangelog.selectTabChangelog(state)
 
   const renderInvocations = mockMarkdownRpc.invocations.filter(([command]) => command === 'Markdown.render')
-  expect(renderInvocations).toHaveLength(4)
-  expect(renderInvocations[0][1]).toContain('Showing the newest 1000 of 5000 GitHub releases')
+  expect(renderInvocations).toHaveLength(1)
+  expect(renderInvocations[0][1]).toContain('Showing the newest 250 of 5000 GitHub releases')
   expect(renderInvocations[0][1]).toContain('Version 5000')
-  expect(renderInvocations.at(-1)?.[1]).toContain('Version 4001')
+  expect(renderInvocations.at(-1)?.[1]).toContain('Version 4751')
 })


### PR DESCRIPTION
Reduces the responsive display cap for repositories with thousands of GitHub releases from 1,000 to 250. The 5,000-release e2e still verifies the full API result is handled, while keeping Chromium on Windows within the workflow timeout.