### PR TITLE
fix: bound GitHub release loading

### DIFF
--- a/packages/e2e/src/extension-detail.changelog-github-5000-releases.ts
+++ b/packages/e2e/src/extension-detail.changelog-github-5000-releases.ts
@@ -4,7 +4,7 @@ import { openGithubChangelog } from './_GithubReleaseTest.js'
 export const test: Test = async (api) => {
   await openGithubChangelog(api, { releaseCount: 5000, type: 'generated' })
   await api.expect(api.Locator('.Changelog h1')).toHaveCount(250)
-  await api.expect(api.Locator('.Changelog')).toContainText('Showing the newest 250 of 5000 GitHub releases')
+  await api.expect(api.Locator('.Changelog')).toContainText('Showing the newest 250 GitHub releases')
   await api.expect(api.Locator('.Changelog')).toContainText('Version 5000')
   await api.expect(api.Locator('.Changelog')).toContainText('Version 4751')
 }

--- a/packages/extension-detail-view-worker/src/parts/LoadGithubReleases/LoadGithubReleases.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadGithubReleases/LoadGithubReleases.ts
@@ -5,7 +5,12 @@ import { GithubReleasesError } from '../GithubReleasesError/GithubReleasesError.
 import { hasProperty } from '../HasProperty/HasProperty.ts'
 
 const pageSize = 100
-const maximumPages = 1000
+const maximumReleases = 250
+
+export interface GithubReleasesResult {
+  readonly isTruncated: boolean
+  readonly releases: readonly GithubRelease[]
+}
 
 const getErrorMessage = async (response: Response): Promise<string> => {
   try {
@@ -102,9 +107,9 @@ const parsePage = async (response: Response): Promise<readonly GithubRelease[]> 
   return releases as readonly GithubRelease[]
 }
 
-export const loadGithubReleases = async ({ owner, repository }: GithubRepository): Promise<readonly GithubRelease[]> => {
+export const loadGithubReleases = async ({ owner, repository }: GithubRepository): Promise<GithubReleasesResult> => {
   const releases: GithubRelease[] = []
-  for (let page = 1; page <= maximumPages; page++) {
+  for (let page = 1; ; page++) {
     const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}/releases?per_page=${pageSize}&page=${page}`
     let response: Response
     try {
@@ -116,10 +121,14 @@ export const loadGithubReleases = async ({ owner, repository }: GithubRepository
       throw await getHttpError(response)
     }
     const pageReleases = await parsePage(response)
+    const remaining = maximumReleases - releases.length
+    if (pageReleases.length > remaining) {
+      releases.push(...pageReleases.slice(0, remaining))
+      return { isTruncated: true, releases }
+    }
     releases.push(...pageReleases)
     if (pageReleases.length < pageSize) {
-      return releases
+      return { isTruncated: false, releases }
     }
   }
-  throw new GithubReleasesError('This repository has too many GitHub releases to display safely.')
 }

--- a/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
+++ b/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
@@ -10,7 +10,6 @@ import { loadGithubReleases } from '../LoadGithubReleases/LoadGithubReleases.ts'
 import * as RenderMarkdown from '../RenderMarkdown/RenderMarkdown.ts'
 
 const releaseBatchSize = 250
-const maximumDisplayedReleases = 250
 
 const mergeMarkdownVirtualDoms = (chunks: readonly (readonly VirtualDomNode[])[]): readonly VirtualDomNode[] => {
   let root: VirtualDomNode | undefined
@@ -27,24 +26,24 @@ const mergeMarkdownVirtualDoms = (chunks: readonly (readonly VirtualDomNode[])[]
 }
 
 const renderGithubReleases = async (
-  releases: Awaited<ReturnType<typeof loadGithubReleases>>,
+  result: Awaited<ReturnType<typeof loadGithubReleases>>,
   githubRepository: NonNullable<ReturnType<typeof getGithubRepository>>,
   languages: ExtensionDetailState['languages'],
   locationProtocol: string,
 ): Promise<readonly VirtualDomNode[]> => {
   const chunks: VirtualDomNode[][] = []
-  const displayedReleases = releases.slice(0, maximumDisplayedReleases)
+  const { isTruncated, releases } = result
   const releaseGroups =
-    displayedReleases.length === 0
+    releases.length === 0
       ? [[]]
-      : Array.from({ length: Math.ceil(displayedReleases.length / releaseBatchSize) }, (_, index) => {
-          return displayedReleases.slice(index * releaseBatchSize, (index + 1) * releaseBatchSize)
+      : Array.from({ length: Math.ceil(releases.length / releaseBatchSize) }, (_, index) => {
+          return releases.slice(index * releaseBatchSize, (index + 1) * releaseBatchSize)
         })
   const baseUrl = `https://github.com/${githubRepository.owner}/${githubRepository.repository}/blob/HEAD/`
   for (const [index, releaseGroup] of releaseGroups.entries()) {
     const limitMessage =
-      index === 0 && releases.length > displayedReleases.length
-        ? `> Showing the newest ${displayedReleases.length} of ${releases.length} GitHub releases. Older releases are not displayed to keep the editor responsive.\n\n`
+      index === 0 && isTruncated
+        ? `> Showing the newest ${releases.length} GitHub releases. Older releases are not displayed to keep the editor responsive.\n\n`
         : ''
     const markdown = limitMessage + getGithubReleasesMarkdown(releaseGroup, githubRepository)
     const html = await RenderMarkdown.renderMarkdown(markdown, { baseUrl, languages, linksExternal: true, locationProtocol })
@@ -59,8 +58,8 @@ export const selectTabChangelog = async (state: ExtensionDetailState): Promise<E
   let changelogDom: readonly VirtualDomNode[]
   if (githubRepository) {
     try {
-      const releases = await loadGithubReleases(githubRepository)
-      changelogDom = await renderGithubReleases(releases, githubRepository, languages, locationProtocol)
+      const result = await loadGithubReleases(githubRepository)
+      changelogDom = await renderGithubReleases(result, githubRepository, languages, locationProtocol)
     } catch (error) {
       const message = error instanceof GithubReleasesError ? error.message : 'GitHub releases could not be loaded. Please try again later.'
       const html = await RenderMarkdown.renderMarkdown(`# Changelog\n\n${message}`, { baseUrl, languages, linksExternal: true, locationProtocol })

--- a/packages/extension-detail-view-worker/test/LoadGithubReleases.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadGithubReleases.test.ts
@@ -17,19 +17,33 @@ afterEach(() => {
 
 test('loads and normalizes releases', async () => {
   GithubApiRequest.mockGithubApi({ body: [release], type: 'success' })
-  await expect(loadGithubReleases(repository)).resolves.toEqual([
-    { body: 'Release notes', htmlUrl: release.html_url, name: 'Version 1', publishedAt: '2026-01-01T00:00:00Z', tagName: 'v1' },
-  ])
+  await expect(loadGithubReleases(repository)).resolves.toEqual({
+    isTruncated: false,
+    releases: [{ body: 'Release notes', htmlUrl: release.html_url, name: 'Version 1', publishedAt: '2026-01-01T00:00:00Z', tagName: 'v1' }],
+  })
 })
 
 test('accepts nullable GitHub fields', async () => {
   GithubApiRequest.mockGithubApi({ body: [{ ...release, body: null, name: null, published_at: null }], type: 'success' })
-  await expect(loadGithubReleases(repository)).resolves.toEqual([{ body: '', htmlUrl: release.html_url, name: '', publishedAt: '', tagName: 'v1' }])
+  await expect(loadGithubReleases(repository)).resolves.toEqual({
+    isTruncated: false,
+    releases: [{ body: '', htmlUrl: release.html_url, name: '', publishedAt: '', tagName: 'v1' }],
+  })
 })
 
 test('loads all paginated releases', async () => {
   GithubApiRequest.mockGithubApi({ releaseCount: 101, type: 'generated' })
-  await expect(loadGithubReleases(repository)).resolves.toHaveLength(101)
+  const result = await loadGithubReleases(repository)
+  expect(result.isTruncated).toBe(false)
+  expect(result.releases).toHaveLength(101)
+})
+
+test('stops loading after the newest 250 releases', async () => {
+  GithubApiRequest.mockGithubApi({ releaseCount: 5000, type: 'generated' })
+  const result = await loadGithubReleases(repository)
+  expect(result).toMatchObject({ isTruncated: true, releases: { length: 250 } })
+  expect(result.releases[0].name).toBe('Version 5000')
+  expect(result.releases.at(-1)?.name).toBe('Version 4751')
 })
 
 test('reports a network error', async () => {

--- a/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
+++ b/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
@@ -120,7 +120,7 @@ test('selectTabChangelog handles 5000 GitHub releases with a responsive display 
 
   const renderInvocations = mockMarkdownRpc.invocations.filter(([command]) => command === 'Markdown.render')
   expect(renderInvocations).toHaveLength(1)
-  expect(renderInvocations[0][1]).toContain('Showing the newest 250 of 5000 GitHub releases')
+  expect(renderInvocations[0][1]).toContain('Showing the newest 250 GitHub releases')
   expect(renderInvocations[0][1]).toContain('Version 5000')
   expect(renderInvocations.at(-1)?.[1]).toContain('Version 4751')
 })


### PR DESCRIPTION
## Summary

- Stop GitHub release pagination once the newest 250 releases have been validated.
- Carry an explicit truncation flag into changelog rendering and show a responsive-limit notice.
- Keep the 5,000-release end-to-end case while avoiding thousands of transient worker objects and API calls.

## Validation

- npm run build
- npm run lint (three pre-existing unused eslint-disable warnings)
- Full worker Jest suite: 1,056 passed, 37 skipped; 95.81% statements, 91.89% branches.