### PR TITLE
fix: limit GitHub changelog to 100 releases

### DIFF
--- a/packages/e2e/src/extension-detail.changelog-github-5000-releases.ts
+++ b/packages/e2e/src/extension-detail.changelog-github-5000-releases.ts
@@ -3,8 +3,8 @@ import { openGithubChangelog } from './_GithubReleaseTest.js'
 
 export const test: Test = async (api) => {
   await openGithubChangelog(api, { releaseCount: 5000, type: 'generated' })
-  await api.expect(api.Locator('.Changelog h1')).toHaveCount(250)
-  await api.expect(api.Locator('.Changelog')).toContainText('Showing the newest 250 GitHub releases')
+  await api.expect(api.Locator('.Changelog h1')).toHaveCount(100)
+  await api.expect(api.Locator('.Changelog')).toContainText('Showing the newest 100 GitHub releases')
   await api.expect(api.Locator('.Changelog')).toContainText('Version 5000')
-  await api.expect(api.Locator('.Changelog')).toContainText('Version 4751')
+  await api.expect(api.Locator('.Changelog')).toContainText('Version 4901')
 }

--- a/packages/e2e/src/extension-detail.changelog-github-pagination.ts
+++ b/packages/e2e/src/extension-detail.changelog-github-pagination.ts
@@ -3,5 +3,6 @@ import { openGithubChangelog } from './_GithubReleaseTest.js'
 
 export const test: Test = async (api) => {
   await openGithubChangelog(api, { releaseCount: 101, type: 'generated' })
-  await api.expect(api.Locator('.Changelog h1')).toHaveCount(101)
+  await api.expect(api.Locator('.Changelog h1')).toHaveCount(100)
+  await api.expect(api.Locator('.Changelog')).toContainText('Older releases are not displayed')
 }

--- a/packages/extension-detail-view-worker/src/parts/LoadGithubReleases/LoadGithubReleases.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadGithubReleases/LoadGithubReleases.ts
@@ -5,7 +5,7 @@ import { GithubReleasesError } from '../GithubReleasesError/GithubReleasesError.
 import { hasProperty } from '../HasProperty/HasProperty.ts'
 
 const pageSize = 100
-const maximumReleases = 250
+const maximumReleases = 100
 
 export interface GithubReleasesResult {
   readonly isTruncated: boolean

--- a/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
+++ b/packages/extension-detail-view-worker/src/parts/SelectTabChangelog/SelectTabChangelog.ts
@@ -9,7 +9,7 @@ import * as LoadChangelogContent from '../LoadChangelogContent/LoadChangelogCont
 import { loadGithubReleases } from '../LoadGithubReleases/LoadGithubReleases.ts'
 import * as RenderMarkdown from '../RenderMarkdown/RenderMarkdown.ts'
 
-const releaseBatchSize = 250
+const releaseBatchSize = 100
 
 const mergeMarkdownVirtualDoms = (chunks: readonly (readonly VirtualDomNode[])[]): readonly VirtualDomNode[] => {
   let root: VirtualDomNode | undefined

--- a/packages/extension-detail-view-worker/test/LoadGithubReleases.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadGithubReleases.test.ts
@@ -31,19 +31,26 @@ test('accepts nullable GitHub fields', async () => {
   })
 })
 
-test('loads all paginated releases', async () => {
+test('detects additional paginated releases', async () => {
   GithubApiRequest.mockGithubApi({ releaseCount: 101, type: 'generated' })
   const result = await loadGithubReleases(repository)
-  expect(result.isTruncated).toBe(false)
-  expect(result.releases).toHaveLength(101)
+  expect(result.isTruncated).toBe(true)
+  expect(result.releases).toHaveLength(100)
 })
 
-test('stops loading after the newest 250 releases', async () => {
+test('does not truncate exactly 100 releases', async () => {
+  GithubApiRequest.mockGithubApi({ releaseCount: 100, type: 'generated' })
+  const result = await loadGithubReleases(repository)
+  expect(result.isTruncated).toBe(false)
+  expect(result.releases).toHaveLength(100)
+})
+
+test('stops loading after the newest 100 releases', async () => {
   GithubApiRequest.mockGithubApi({ releaseCount: 5000, type: 'generated' })
   const result = await loadGithubReleases(repository)
-  expect(result).toMatchObject({ isTruncated: true, releases: { length: 250 } })
+  expect(result).toMatchObject({ isTruncated: true, releases: { length: 100 } })
   expect(result.releases[0].name).toBe('Version 5000')
-  expect(result.releases.at(-1)?.name).toBe('Version 4751')
+  expect(result.releases.at(-1)?.name).toBe('Version 4901')
 })
 
 test('reports a network error', async () => {

--- a/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
+++ b/packages/extension-detail-view-worker/test/SelectTabChangelog.test.ts
@@ -120,7 +120,7 @@ test('selectTabChangelog handles 5000 GitHub releases with a responsive display 
 
   const renderInvocations = mockMarkdownRpc.invocations.filter(([command]) => command === 'Markdown.render')
   expect(renderInvocations).toHaveLength(1)
-  expect(renderInvocations[0][1]).toContain('Showing the newest 250 GitHub releases')
+  expect(renderInvocations[0][1]).toContain('Showing the newest 100 GitHub releases')
   expect(renderInvocations[0][1]).toContain('Version 5000')
-  expect(renderInvocations.at(-1)?.[1]).toContain('Version 4751')
+  expect(renderInvocations.at(-1)?.[1]).toContain('Version 4901')
 })


### PR DESCRIPTION
## Summary

- Render at most the newest 100 GitHub releases.
- Probe the next API page to distinguish exactly 100 releases from a truncated result.
- Keep both the 101-release pagination test and 5,000-release stress test, with a friendly notice when older entries are omitted.

## Validation

- Focused worker tests: 28 passed.
- npm run build.
- Prettier check passed.

This follows #1389 after its optional Windows job showed that a 250-entry markdown DOM still crashes the shared Windows browser.