### PR TITLE
feature: expose extension detail title

### DIFF
--- a/packages/extension-detail-view-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/extension-detail-view-worker/src/parts/CommandMap/CommandMap.ts
@@ -47,6 +47,7 @@ import * as LoadContent2 from '../LoadContent2/LoadContent2.ts'
 import * as OpenImageInNewTab from '../OpenImageInNewTab/OpenImageInNewTab.ts'
 import * as Render2 from '../Render2/Render2.ts'
 import * as RenderEventListeners from '../RenderEventListeners/RenderEventListeners.ts'
+import * as RenderTitle from '../RenderTitle/RenderTitle.ts'
 import * as Resize from '../Resize/Resize.ts'
 import * as SaveState from '../SaveState/SaveState.ts'
 import * as SelectTab from '../SelectTab/SelectTab.ts'
@@ -100,6 +101,7 @@ export const commandMap = {
   'ExtensionDetail.openImageInNewTab': WrapCommand.wrapCommand(OpenImageInNewTab.openImageInNewTab),
   'ExtensionDetail.render2': Render2.render2,
   'ExtensionDetail.renderEventListeners': RenderEventListeners.renderEventListeners,
+  'ExtensionDetail.renderTitle': WrapCommand.wrapGetter(RenderTitle.renderTitle),
   'ExtensionDetail.resetGithubApiMock': WrapCommand.wrapCommand(GithubApiRequest.handleResetGithubApiMock),
   'ExtensionDetail.resize': WrapCommand.wrapCommand(Resize.resize),
   'ExtensionDetail.saveState': WrapCommand.wrapGetter(SaveState.saveState),

--- a/packages/extension-detail-view-worker/src/parts/RenderTitle/RenderTitle.ts
+++ b/packages/extension-detail-view-worker/src/parts/RenderTitle/RenderTitle.ts
@@ -1,0 +1,5 @@
+import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
+
+export const renderTitle = (state: ExtensionDetailState): string => {
+  return state.name
+}

--- a/packages/extension-detail-view-worker/test/RenderTitle.test.ts
+++ b/packages/extension-detail-view-worker/test/RenderTitle.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { renderTitle } from '../src/parts/RenderTitle/RenderTitle.ts'
+
+test('returns the loaded extension name', () => {
+  const state = {
+    ...createDefaultState(),
+    name: 'Atom One Dark Theme',
+  }
+
+  expect(renderTitle(state)).toBe('Atom One Dark Theme')
+})
+
+test('returns an empty title when no extension name is available', () => {
+  const state = createDefaultState()
+
+  expect(renderTitle(state)).toBe('')
+})


### PR DESCRIPTION
Expose the loaded extension display name through an ExtensionDetail.renderTitle command so editor providers can supply a user-facing tab title.