### PR TITLE
fix: hide unavailable extension metrics

### DIFF
--- a/packages/e2e/fixtures/extension-builtin/extension.json
+++ b/packages/e2e/fixtures/extension-builtin/extension.json
@@ -3,5 +3,7 @@
   "name": "Test Builtin Extension",
   "description": "Test Builtin Extension Description",
   "builtin": true,
+  "downloadCount": 12345,
+  "rating": 4.75,
   "categories": ["Themes"]
 }

--- a/packages/e2e/src/extension-detail.builtin-marketplace-hidden.ts
+++ b/packages/e2e/src/extension-detail.builtin-marketplace-hidden.ts
@@ -9,6 +9,12 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await ExtensionDetail.open('test.extension-builtin')
 
   // assert
+  const metadata = Locator('.ExtensionDetailMetadata')
+  await expect(metadata).toHaveCount(0)
+  const downloadCount = Locator('.ExtensionDetailDownloadCount')
+  await expect(downloadCount).toHaveCount(0)
+  const rating = Locator('.ExtensionDetailRating')
+  await expect(rating).toHaveCount(0)
   const headings = Locator('.AdditionalDetailsTitle')
   await expect(headings).toHaveCount(3)
   const installationHeading = headings.nth(0)

--- a/packages/e2e/src/extension-detail.no-readme.ts
+++ b/packages/e2e/src/extension-detail.no-readme.ts
@@ -14,4 +14,10 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   const icon = Locator('.Markdown')
   await expect(icon).toBeVisible()
   await expect(icon).toHaveText('No Readme Found.')
+  const metadata = Locator('.ExtensionDetailMetadata')
+  await expect(metadata).toHaveCount(0)
+  const downloadCount = Locator('.ExtensionDetailDownloadCount')
+  await expect(downloadCount).toHaveCount(0)
+  const rating = Locator('.ExtensionDetailRating')
+  await expect(rating).toHaveCount(0)
 }

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailHeaderVirtualDom/GetExtensionDetailHeaderVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailHeaderVirtualDom/GetExtensionDetailHeaderVirtualDom.ts
@@ -19,6 +19,7 @@ export const getExtensionDetailHeaderVirtualDom = (
   downloadCount: string = 'n/a',
   rating: string = 'n/a',
 ): readonly VirtualDomNode[] => {
+  const metadataDom = getExtensionDetailMetadataVirtualDom(downloadCount, rating)
   const dom = [
     {
       childCount: 2,
@@ -27,14 +28,14 @@ export const getExtensionDetailHeaderVirtualDom = (
     },
     getExtensionDetailIconVirtualDom(iconSrc),
     {
-      childCount: 4,
+      childCount: metadataDom.length > 0 ? 4 : 3,
       className: ClassNames.ExtensionDetailHeaderDetails,
       onContextMenu: DomEventListenerFunctions.HandleHeaderContextMenu,
       type: VirtualDomElements.Div,
     },
     ...getExtensionDetailNameVirtualDom(name, badge),
     ...getExtensionDetailDescriptionVirtualDom(description),
-    ...getExtensionDetailMetadataVirtualDom(downloadCount, rating),
+    ...metadataDom,
     ...GetExtensionDetailHeaderActionsVirtualDom.getExtensionDetailHeaderActionsVirtualDom(buttonDefs, settingsButtonEnabled),
   ]
   return dom

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailMetadataVirtualDom/GetExtensionDetailMetadataVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailMetadataVirtualDom/GetExtensionDetailMetadataVirtualDom.ts
@@ -20,13 +20,22 @@ const getStatisticVirtualDom = (label: string, value: string, className: string)
 }
 
 export const getExtensionDetailMetadataVirtualDom = (downloadCount: string, rating: string): readonly VirtualDomNode[] => {
+  const hasDownloadCount = downloadCount !== 'n/a'
+  const hasRating = rating !== 'n/a'
+  if (!hasDownloadCount && !hasRating) {
+    return []
+  }
+  const downloadCountDom = hasDownloadCount
+    ? getStatisticVirtualDom(ExtensionDetailStrings.downloadCount(), downloadCount, ClassNames.ExtensionDetailDownloadCount)
+    : []
+  const ratingDom = hasRating ? getStatisticVirtualDom(ExtensionDetailStrings.rating(), rating, ClassNames.ExtensionDetailRating) : []
   return [
     {
-      childCount: 2,
+      childCount: Number(hasDownloadCount) + Number(hasRating),
       className: ClassNames.ExtensionDetailMetadata,
       type: VirtualDomElements.Div,
     },
-    ...getStatisticVirtualDom(ExtensionDetailStrings.downloadCount(), downloadCount, ClassNames.ExtensionDetailDownloadCount),
-    ...getStatisticVirtualDom(ExtensionDetailStrings.rating(), rating, ClassNames.ExtensionDetailRating),
+    ...downloadCountDom,
+    ...ratingDom,
   ]
 }

--- a/packages/extension-detail-view-worker/src/parts/LoadHeaderContent/LoadHeaderContent.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadHeaderContent/LoadHeaderContent.ts
@@ -13,10 +13,10 @@ export const loadHeaderContent = (state: ExtensionDetailState, platform: number,
   const extensionId = extension?.id || 'n/a'
   const extensionVersion = extension?.version || 'n/a'
   const hasColorTheme = HasColorThemes.hasColorThemes(extension)
-  const isBuiltin = extension?.builtin
+  const isBuiltin = extension?.isBuiltin || extension?.builtin || false
   const badge = GetBadge.getBadge(isBuiltin, builtinExtensionsBadgeEnabled)
-  const downloadCount = ExtensionDisplay.getDownloadCount(extension)
-  const rating = ExtensionDisplay.getRating(extension)
+  const downloadCount = isBuiltin ? 'n/a' : ExtensionDisplay.getDownloadCount(extension)
+  const rating = isBuiltin ? 'n/a' : ExtensionDisplay.getRating(extension)
   return {
     badge,
     description,

--- a/packages/extension-detail-view-worker/test/GetExtensionDetailHeaderVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetExtensionDetailHeaderVirtualDom.test.ts
@@ -12,11 +12,41 @@ test('adds a context menu listener to the extension detail header details', () =
   const result = GetExtensionDetailHeaderVirtualDom.getExtensionDetailHeaderVirtualDom('name', 'icon.png', 'description', '', [], false)
 
   expect(result[2]).toEqual({
-    childCount: 4,
+    childCount: 3,
     className: ClassNames.ExtensionDetailHeaderDetails,
     onContextMenu: DomEventListenerFunctions.HandleHeaderContextMenu,
     type: VirtualDomElements.Div,
   })
+})
+
+test('does not render extension metadata when values are unavailable', () => {
+  const result = GetExtensionDetailHeaderVirtualDom.getExtensionDetailHeaderVirtualDom('name', 'icon.png', 'description', '', [], false)
+
+  expect(result).not.toContainEqual(
+    expect.objectContaining({
+      className: ClassNames.ExtensionDetailMetadata,
+    }),
+  )
+})
+
+test('renders only available extension metadata', () => {
+  const result = GetExtensionDetailHeaderVirtualDom.getExtensionDetailHeaderVirtualDom('name', 'icon.png', 'description', '', [], false, '98,765')
+
+  expect(result.slice(7, 10)).toEqual([
+    {
+      childCount: 1,
+      className: ClassNames.ExtensionDetailMetadata,
+      type: VirtualDomElements.Div,
+    },
+    {
+      ariaLabel: 'Downloads: 98,765',
+      childCount: 1,
+      className: `${ClassNames.ExtensionDetailStatistic} ${ClassNames.ExtensionDetailDownloadCount}`,
+      title: 'Downloads: 98,765',
+      type: VirtualDomElements.Span,
+    },
+    text('98,765'),
+  ])
 })
 
 test('renders download count and rating in the extension detail header', () => {

--- a/packages/extension-detail-view-worker/test/LoadHeaderContent.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadHeaderContent.test.ts
@@ -35,9 +35,11 @@ test('loadHeaderContent - with builtin extension', async () => {
   const mockExtension: any = {
     builtin: true,
     description: 'A builtin extension',
+    downloadCount: 12_345,
     id: 'builtin-extension',
     name: 'Builtin Extension',
     path: '/test/path',
+    rating: 4.75,
     version: '1.0.0',
   }
 
@@ -51,6 +53,8 @@ test('loadHeaderContent - with builtin extension', async () => {
   expect(result.extension).toEqual(mockExtension)
   expect(result.extensionId).toBe('builtin-extension')
   expect(result.name).toBe('Builtin Extension')
+  expect(result.downloadCount).toBe('n/a')
+  expect(result.rating).toBe('n/a')
 })
 
 test('loadHeaderContent - with fallback values', async () => {


### PR DESCRIPTION
Hide download and rating metadata for builtin extensions, and omit individual metrics when their values are unavailable. Add e2e regression coverage for builtin and missing metadata.