### PR TITLE
feature: add extension detail metadata e2e tests

### DIFF
--- a/packages/e2e/fixtures/extension-download-count-only/extension.json
+++ b/packages/e2e/fixtures/extension-download-count-only/extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "test.extension-download-count-only",
+  "name": "Download Count Only",
+  "description": "Extension with a download count but no rating",
+  "downloadCount": 9876543
+}

--- a/packages/e2e/fixtures/extension-rating-only/extension.json
+++ b/packages/e2e/fixtures/extension-rating-only/extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "test.extension-rating-only",
+  "name": "Rating Only",
+  "description": "Extension with a rating but no download count",
+  "rating": 3.25
+}

--- a/packages/e2e/src/extension-detail.metadata-accessibility.ts
+++ b/packages/e2e/src/extension-detail.metadata-accessibility.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.metadata-accessibility'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-basics')
+
+  // assert
+  const downloadCount = Locator('.ExtensionDetailDownloadCount')
+  const rating = Locator('.ExtensionDetailRating')
+  await expect(downloadCount).toHaveAttribute('aria-label', 'Downloads: 12,345')
+  await expect(downloadCount).toHaveAttribute('title', 'Downloads: 12,345')
+  await expect(rating).toHaveAttribute('aria-label', 'Rating: 4.8')
+  await expect(rating).toHaveAttribute('title', 'Rating: 4.8')
+}

--- a/packages/e2e/src/extension-detail.metadata-download-count-only.ts
+++ b/packages/e2e/src/extension-detail.metadata-download-count-only.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.metadata-download-count-only'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-download-count-only')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-download-count-only')
+
+  // assert
+  const metadata = Locator('.ExtensionDetailMetadata')
+  await expect(metadata).toBeVisible()
+  const downloadCount = Locator('.ExtensionDetailDownloadCount')
+  await expect(downloadCount).toHaveText('9,876,543')
+  const rating = Locator('.ExtensionDetailRating')
+  await expect(rating).toHaveCount(0)
+}

--- a/packages/e2e/src/extension-detail.metadata-rating-only.ts
+++ b/packages/e2e/src/extension-detail.metadata-rating-only.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.metadata-rating-only'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-rating-only')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-rating-only')
+
+  // assert
+  const metadata = Locator('.ExtensionDetailMetadata')
+  await expect(metadata).toBeVisible()
+  const downloadCount = Locator('.ExtensionDetailDownloadCount')
+  await expect(downloadCount).toHaveCount(0)
+  const rating = Locator('.ExtensionDetailRating')
+  await expect(rating).toHaveText('3.3')
+}

--- a/packages/e2e/src/extension-detail.metadata-switch-clears.ts
+++ b/packages/e2e/src/extension-detail.metadata-switch-clears.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.metadata-switch-clears'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const basicsUri = import.meta.resolve('../fixtures/extension-basics')
+  const resourceUri = import.meta.resolve('../fixtures/extension-resource-github')
+  await Extension.addWebExtension(basicsUri)
+  await Extension.addWebExtension(resourceUri)
+  await ExtensionDetail.open('test.extension-basics')
+  const metadata = Locator('.ExtensionDetailMetadata')
+  await expect(metadata).toBeVisible()
+
+  // act
+  await ExtensionDetail.open('test.extension-resource-github')
+
+  // assert
+  await expect(metadata).toHaveCount(0)
+  const extensionName = Locator('.ExtensionDetailName')
+  await expect(extensionName).toHaveText('GitHub Resources')
+}


### PR DESCRIPTION
Adds extension detail e2e coverage for partial marketplace metadata, metadata accessibility, and clearing stale metadata when switching extensions.