### PR TITLE
fix: refresh theme action after color theme changes

### DIFF
--- a/packages/e2e/src/extension-detail.set-color-theme-button-reappears.ts
+++ b/packages/e2e/src/extension-detail.set-color-theme-button-reappears.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.set-color-theme-button-reappears'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, ExtensionDetail, Locator, QuickPick }) => {
+  // arrange
+  await Command.execute('ColorTheme.setColorTheme', 'slime')
+  await ExtensionDetail.open('builtin.theme-cobalt2')
+  const setColorThemeButton = Locator('.Button[name="SetColorTheme"]')
+  await expect(setColorThemeButton).toBeVisible()
+  await ExtensionDetail.handleClickSetColorTheme()
+  await expect(setColorThemeButton).toBeHidden()
+
+  // act
+  await QuickPick.executeCommand('>Preferences: Color Theme')
+  await QuickPick.selectItem('slime')
+
+  // assert
+  await expect(setColorThemeButton).toBeVisible()
+}

--- a/packages/extension-detail-view-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/extension-detail-view-worker/src/parts/CommandMap/CommandMap.ts
@@ -26,6 +26,7 @@ import * as HandleClickSetColorTheme from '../HandleClickSetColorTheme/HandleCli
 import * as HandleClickSettings from '../HandleClickSettings/HandleClickSettings.ts'
 import * as HandleClickSize from '../HandleClickSize/HandleClickSize.ts'
 import * as HandleClickUninstall from '../HandleClickUninstall/HandleClickUninstall.ts'
+import { handleColorThemeChanged } from '../HandleColorThemeChanged/HandleColorThemeChanged.ts'
 import { handleExtensionsChanged } from '../HandleExtensionsChanged/HandleExtensionsChanged.ts'
 import * as HandleExtensionsStatusUpdate from '../HandleExtensionsStatusUpdate/HandleExtensionsStatusUpdate.ts'
 import { handleHeaderContextMenu } from '../HandleHeaderContextMenu/HandleHeaderContextMenu.ts'
@@ -77,6 +78,7 @@ export const commandMap = {
   'ExtensionDetail.handleClickSettings': WrapCommand.wrapCommand(HandleClickSettings.handleClickSettings),
   'ExtensionDetail.handleClickSize': WrapCommand.wrapCommand(HandleClickSize.handleClickSize),
   'ExtensionDetail.handleClickUninstall': WrapCommand.wrapCommand(HandleClickUninstall.handleClickUninstall),
+  'ExtensionDetail.handleColorThemeChanged': WrapCommand.wrapCommand(handleColorThemeChanged),
   'ExtensionDetail.handleExtensionsChanged': WrapCommand.wrapCommand(handleExtensionsChanged),
   'ExtensionDetail.handleExtensionsStatusUpdate': WrapCommand.wrapCommand(HandleExtensionsStatusUpdate.handleExtensionsStatusUpdate),
   'ExtensionDetail.handleFeaturesClick': WrapCommand.wrapCommand(HandleClickFeatures.handleClickFeatures),

--- a/packages/extension-detail-view-worker/src/parts/HandleColorThemeChanged/HandleColorThemeChanged.ts
+++ b/packages/extension-detail-view-worker/src/parts/HandleColorThemeChanged/HandleColorThemeChanged.ts
@@ -1,0 +1,19 @@
+import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
+import { getColorThemeId, getColorThemeLabel } from '../GetColorThemeId/GetColorThemeId.ts'
+import { getExtensionDetailButtons } from '../GetExtensionDetailButtons/GetExtensionDetailButtons.ts'
+
+export const handleColorThemeChanged = (state: ExtensionDetailState, colorThemeId: string): ExtensionDetailState => {
+  if (state.currentColorThemeId === colorThemeId) {
+    return state
+  }
+  const { disabled, extension, hasColorTheme } = state
+  const extensionColorThemeId = getColorThemeId(extension) || ''
+  const extensionColorThemeLabel = getColorThemeLabel(extension) || ''
+  const isBuiltin = extension?.isBuiltin || extension?.builtin || false
+  const buttons = getExtensionDetailButtons(hasColorTheme, isBuiltin, disabled, extensionColorThemeId, extensionColorThemeLabel, colorThemeId)
+  return {
+    ...state,
+    buttons,
+    currentColorThemeId: colorThemeId,
+  }
+}

--- a/packages/extension-detail-view-worker/test/HandleColorThemeChanged.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleColorThemeChanged.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@jest/globals'
+import * as CreateDefaultState from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleColorThemeChanged } from '../src/parts/HandleColorThemeChanged/HandleColorThemeChanged.ts'
+
+test('shows set color theme button when another color theme becomes active', () => {
+  const state = {
+    ...CreateDefaultState.createDefaultState(),
+    currentColorThemeId: 'cobalt2',
+    extension: {
+      builtin: true,
+      colorThemes: [{ id: 'cobalt2', label: 'Cobalt 2' }],
+    },
+    hasColorTheme: true,
+  }
+
+  const result = handleColorThemeChanged(state, 'slime')
+
+  expect(result.currentColorThemeId).toBe('slime')
+  expect(result.buttons.some((button) => button.name === 'SetColorTheme')).toBe(true)
+})
+
+test('hides set color theme button when extension color theme becomes active', () => {
+  const state = {
+    ...CreateDefaultState.createDefaultState(),
+    extension: {
+      colorThemes: [{ id: 'cobalt2', label: 'Cobalt 2' }],
+    },
+    hasColorTheme: true,
+  }
+
+  const result = handleColorThemeChanged(state, 'cobalt2')
+
+  expect(result.currentColorThemeId).toBe('cobalt2')
+  expect(result.buttons.some((button) => button.name === 'SetColorTheme')).toBe(false)
+})
+
+test('returns the same state when the color theme did not change', () => {
+  const state = {
+    ...CreateDefaultState.createDefaultState(),
+    currentColorThemeId: 'cobalt2',
+  }
+
+  const result = handleColorThemeChanged(state, 'cobalt2')
+
+  expect(result).toBe(state)
+})


### PR DESCRIPTION
Updates extension detail state when the active color theme changes so the Set Color Theme action reappears when appropriate. Adds unit coverage and an e2e regression for switching Cobalt 2 back to slime.