### PR TITLE
fix: open server extension details

### DIFF
--- a/packages/extension-detail-view-worker/src/parts/ExtensionManagement/ExtensionManagement.ts
+++ b/packages/extension-detail-view-worker/src/parts/ExtensionManagement/ExtensionManagement.ts
@@ -4,7 +4,10 @@ import * as GetExtensionFallback from '../GetExtensionFallback/GetExtensionFallb
 const getExtensionNew = async (id: string): Promise<any> => {
   try {
     const rpc = get(RpcId.ExtensionManagementWorker)
-    return await rpc.invoke('Extensions.getExtension', id)
+    const extension = await rpc.invoke('Extensions.getExtension', id)
+    if (extension) {
+      return extension
+    }
   } catch {
     // ignore
   }

--- a/packages/extension-detail-view-worker/test/ExtensionManagement.test.ts
+++ b/packages/extension-detail-view-worker/test/ExtensionManagement.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as ExtensionManagement from '../src/parts/ExtensionManagement/ExtensionManagement.ts'
 import * as PlatformType from '../src/parts/PlatformType/PlatformType.ts'
 
@@ -13,6 +13,36 @@ test('getExtension - successful getExtension', async () => {
   const result: any = await ExtensionManagement.getExtension('test-id', PlatformType.Electron)
   expect(result).toEqual(mockExtension)
   expect(mockRpc.invocations).toEqual([['ExtensionManagement.getExtension', 'test-id']])
+})
+
+test('getExtension - successful extension management worker lookup', async () => {
+  const extension = { id: 'test-id', name: 'Test Extension' }
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getExtension': () => {
+      return extension
+    },
+  })
+
+  await expect(ExtensionManagement.getExtension(extension.id, PlatformType.Web)).resolves.toEqual(extension)
+  expect(mockRpc.invocations).toEqual([['Extensions.getExtension', extension.id]])
+})
+
+test('getExtension - fallback to server extension when extension management worker returns undefined', async () => {
+  const serverExtension = { id: 'builtin.high-contrast-theme', name: 'High Contrast Theme' }
+  using extensionManagementMockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getExtension': () => {
+      return undefined
+    },
+  })
+  using rendererMockRpc = RendererWorker.registerMockRpc({
+    'ExtensionManagement.getExtension': () => {
+      return serverExtension
+    },
+  })
+
+  await expect(ExtensionManagement.getExtension(serverExtension.id, PlatformType.Web)).resolves.toEqual(serverExtension)
+  expect(extensionManagementMockRpc.invocations).toEqual([['Extensions.getExtension', serverExtension.id]])
+  expect(rendererMockRpc.invocations).toEqual([['ExtensionManagement.getExtension', serverExtension.id]])
 })
 
 test('getExtension - fallback to getAllExtensions when getExtension fails', async () => {


### PR DESCRIPTION
Summary:
- fall back to the server extension lookup when the extension-management worker does not contain an extension
- cover both direct and server-fallback detail lookups