### PR TITLE
feature: add ten extension detail e2e tests

### DIFF
--- a/packages/e2e/fixtures/extension-activation-events-invalid-item-array/extension.json
+++ b/packages/e2e/fixtures/extension-activation-events-invalid-item-array/extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "test.activation-events-invalid-item-array",
+  "name": "Activation Events Invalid Item Array",
+  "description": "Extension with an invalid array activation event",
+  "activation": [["onStartup"]]
+}

--- a/packages/e2e/fixtures/extension-activation-events-invalid-item-boolean/extension.json
+++ b/packages/e2e/fixtures/extension-activation-events-invalid-item-boolean/extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "test.activation-events-invalid-item-boolean",
+  "name": "Activation Events Invalid Item Boolean",
+  "description": "Extension with an invalid boolean activation event",
+  "activation": [true]
+}

--- a/packages/e2e/fixtures/extension-category-array-invalid-item-array/extension.json
+++ b/packages/e2e/fixtures/extension-category-array-invalid-item-array/extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "test.extension-category-array-invalid-item-array",
+  "name": "Category Array Invalid Item Array",
+  "description": "Extension with an invalid array category",
+  "categories": [["Themes"]]
+}

--- a/packages/e2e/fixtures/extension-category-array-invalid-item-boolean/extension.json
+++ b/packages/e2e/fixtures/extension-category-array-invalid-item-boolean/extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "test.extension-category-array-invalid-item-boolean",
+  "name": "Category Array Invalid Item Boolean",
+  "description": "Extension with an invalid boolean category",
+  "categories": [false]
+}

--- a/packages/e2e/fixtures/extension-category-array-invalid-item-number/extension.json
+++ b/packages/e2e/fixtures/extension-category-array-invalid-item-number/extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "test.extension-category-array-invalid-item-number",
+  "name": "Category Array Invalid Item Number",
+  "description": "Extension with an invalid number category",
+  "categories": [123]
+}

--- a/packages/e2e/fixtures/extension-category-array-invalid-item-object/extension.json
+++ b/packages/e2e/fixtures/extension-category-array-invalid-item-object/extension.json
@@ -1,0 +1,10 @@
+{
+  "id": "test.extension-category-array-invalid-item-object",
+  "name": "Category Array Invalid Item Object",
+  "description": "Extension with an invalid object category",
+  "categories": [
+    {
+      "name": "Themes"
+    }
+  ]
+}

--- a/packages/e2e/fixtures/extension-repository-invalid-array/extension.json
+++ b/packages/e2e/fixtures/extension-repository-invalid-array/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "test.extension-repository-invalid-array",
+  "name": "Repository Invalid Array",
+  "description": "Extension with an invalid array repository",
+  "repository": [],
+  "categories": ["Other"]
+}

--- a/packages/e2e/fixtures/extension-repository-invalid-boolean/extension.json
+++ b/packages/e2e/fixtures/extension-repository-invalid-boolean/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "test.extension-repository-invalid-boolean",
+  "name": "Repository Invalid Boolean",
+  "description": "Extension with an invalid boolean repository",
+  "repository": false,
+  "categories": ["Other"]
+}

--- a/packages/e2e/fixtures/extension-repository-invalid-number/extension.json
+++ b/packages/e2e/fixtures/extension-repository-invalid-number/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "test.extension-repository-invalid-number",
+  "name": "Repository Invalid Number",
+  "description": "Extension with an invalid number repository",
+  "repository": 123,
+  "categories": ["Other"]
+}

--- a/packages/e2e/fixtures/extension-repository-invalid-object/extension.json
+++ b/packages/e2e/fixtures/extension-repository-invalid-object/extension.json
@@ -1,0 +1,9 @@
+{
+  "id": "test.extension-repository-invalid-object",
+  "name": "Repository Invalid Object",
+  "description": "Extension with an invalid object repository",
+  "repository": {
+    "url": "https://github.com/lvce-editor/extension-detail-view"
+  },
+  "categories": ["Other"]
+}

--- a/packages/e2e/src/extension-detail.category-array-invalid-item-array.ts
+++ b/packages/e2e/src/extension-detail.category-array-invalid-item-array.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.category-array-invalid-item-array'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-category-array-invalid-item-array')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-category-array-invalid-item-array')
+
+  // assert
+  const category = Locator('.ExtensionDetail .Category')
+  await expect(category).toHaveCount(1)
+  await expect(category).toHaveText('["Themes"]')
+}

--- a/packages/e2e/src/extension-detail.category-array-invalid-item-boolean.ts
+++ b/packages/e2e/src/extension-detail.category-array-invalid-item-boolean.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.category-array-invalid-item-boolean'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-category-array-invalid-item-boolean')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-category-array-invalid-item-boolean')
+
+  // assert
+  const category = Locator('.ExtensionDetail .Category')
+  await expect(category).toHaveCount(1)
+  await expect(category).toHaveText('false')
+}

--- a/packages/e2e/src/extension-detail.category-array-invalid-item-number.ts
+++ b/packages/e2e/src/extension-detail.category-array-invalid-item-number.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.category-array-invalid-item-number'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-category-array-invalid-item-number')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-category-array-invalid-item-number')
+
+  // assert
+  const category = Locator('.ExtensionDetail .Category')
+  await expect(category).toHaveCount(1)
+  await expect(category).toHaveText('123')
+}

--- a/packages/e2e/src/extension-detail.category-array-invalid-item-object.ts
+++ b/packages/e2e/src/extension-detail.category-array-invalid-item-object.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.category-array-invalid-item-object'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-category-array-invalid-item-object')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-category-array-invalid-item-object')
+
+  // assert
+  const category = Locator('.ExtensionDetail .Category')
+  await expect(category).toHaveCount(1)
+  await expect(category).toHaveText('{"name":"Themes"}')
+}

--- a/packages/e2e/src/extension-detail.feature-activation-events-invalid-item-array.ts
+++ b/packages/e2e/src/extension-detail.feature-activation-events-invalid-item-array.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-activation-events-invalid-item-array'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-activation-events-invalid-item-array')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.activation-events-invalid-item-array')
+  await ExtensionDetail.selectFeatures()
+
+  // act
+  await ExtensionDetail.openFeature('ActivationEvents')
+
+  // assert
+  const item = Locator('.FeatureContent li').nth(0)
+  await expect(item).toBeVisible()
+  await expect(item).toHaveClass('ListItemInvalid')
+  await expect(item).toHaveText('["onStartup"]')
+  await expect(item).toHaveAttribute('title', 'Property must be a string')
+}

--- a/packages/e2e/src/extension-detail.feature-activation-events-invalid-item-boolean.ts
+++ b/packages/e2e/src/extension-detail.feature-activation-events-invalid-item-boolean.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-activation-events-invalid-item-boolean'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-activation-events-invalid-item-boolean')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.activation-events-invalid-item-boolean')
+  await ExtensionDetail.selectFeatures()
+
+  // act
+  await ExtensionDetail.openFeature('ActivationEvents')
+
+  // assert
+  const item = Locator('.FeatureContent li').nth(0)
+  await expect(item).toBeVisible()
+  await expect(item).toHaveClass('ListItemInvalid')
+  await expect(item).toHaveText('true')
+  await expect(item).toHaveAttribute('title', 'Property must be a string')
+}

--- a/packages/e2e/src/extension-detail.repository-invalid-array.ts
+++ b/packages/e2e/src/extension-detail.repository-invalid-array.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.repository-invalid-array'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-repository-invalid-array')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-repository-invalid-array')
+
+  // assert
+  const repository = Locator('.ExtensionDetail .AdditionalDetailsEntry').nth(3).locator('.Resource').nth(2)
+  await expect(repository).toBeVisible()
+  await expect(repository).toHaveText('Repository')
+  await expect(repository).toHaveAttribute('href', null)
+}

--- a/packages/e2e/src/extension-detail.repository-invalid-boolean.ts
+++ b/packages/e2e/src/extension-detail.repository-invalid-boolean.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.repository-invalid-boolean'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-repository-invalid-boolean')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-repository-invalid-boolean')
+
+  // assert
+  const repository = Locator('.ExtensionDetail .AdditionalDetailsEntry').nth(3).locator('.Resource').nth(2)
+  await expect(repository).toBeVisible()
+  await expect(repository).toHaveText('Repository')
+  await expect(repository).toHaveAttribute('href', null)
+}

--- a/packages/e2e/src/extension-detail.repository-invalid-number.ts
+++ b/packages/e2e/src/extension-detail.repository-invalid-number.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.repository-invalid-number'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-repository-invalid-number')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-repository-invalid-number')
+
+  // assert
+  const repository = Locator('.ExtensionDetail .AdditionalDetailsEntry').nth(3).locator('.Resource').nth(2)
+  await expect(repository).toBeVisible()
+  await expect(repository).toHaveText('Repository')
+  await expect(repository).toHaveAttribute('href', null)
+}

--- a/packages/e2e/src/extension-detail.repository-invalid-object.ts
+++ b/packages/e2e/src/extension-detail.repository-invalid-object.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.repository-invalid-object'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-repository-invalid-object')
+  await Extension.addWebExtension(extensionUri)
+
+  // act
+  await ExtensionDetail.open('test.extension-repository-invalid-object')
+
+  // assert
+  const repository = Locator('.ExtensionDetail .AdditionalDetailsEntry').nth(3).locator('.Resource').nth(2)
+  await expect(repository).toBeVisible()
+  await expect(repository).toHaveText('Repository')
+  await expect(repository).toHaveAttribute('href', null)
+}


### PR DESCRIPTION
Add boundary e2e coverage for invalid activation-event, category, and repository manifest values.

This increases the extension-detail e2e suite from 140 to 150 scenarios.