### PR TITLE
feature: hoist static virtual dom nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lerna/legacy-package-management": "^8.2.4",
-        "@lvce-editor/eslint-config": "^16.4.0",
+        "@lvce-editor/eslint-config": "^17.0.3",
         "@lvce-editor/eslint-plugin-github-actions": "^10.2.0",
         "eslint": "^10.7.0",
         "knip": "^6.20.0",
@@ -1703,9 +1703,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-16.4.0.tgz",
-      "integrity": "sha512-vc382ImEo+upv9LR+kr0vSpfyV8BBxKb+m2nCBVXjGm7eu5Cw9zTPv9X+mxOjWiNkUyWfuwY+NgbgsSC4Scu8g==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.0.3.tgz",
+      "integrity": "sha512-ChzOGQfCDANWLZlaR05tO6880FDTz9RZ+ATbijYSEByVDzdMSCgoDBPOzOXKDyCpeIR6KZ2I+O80mvNKTYlEgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1715,14 +1715,14 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "16.4.0",
-        "@lvce-editor/eslint-plugin-e2e": "16.4.0",
-        "@lvce-editor/eslint-plugin-github-actions": "16.4.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "16.4.0",
-        "@lvce-editor/eslint-plugin-regex": "16.4.0",
-        "@lvce-editor/eslint-plugin-rpc": "16.4.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "16.4.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "16.4.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.0.3",
+        "@lvce-editor/eslint-plugin-e2e": "17.0.3",
+        "@lvce-editor/eslint-plugin-github-actions": "17.0.3",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.0.3",
+        "@lvce-editor/eslint-plugin-regex": "17.0.3",
+        "@lvce-editor/eslint-plugin-rpc": "17.0.3",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.0.3",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.0.3",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -1737,9 +1737,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config/node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-16.4.0.tgz",
-      "integrity": "sha512-T66LFDS0nX3/H5nxFiNIkUMEou55FlOxLgOfkbCivZdQQ+fTZnNYb1zOdkxk9hKzQC6RaO4Oj0soilT02TDOQQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.0.3.tgz",
+      "integrity": "sha512-+LMl161bH/f6iS4H+Uc/9lkZnF7jZOxChV2ghn0u9v3326r0rIfbE2eUiaWWZIxh2ox1qWXPWyGhyqxkdkUBjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-16.4.0.tgz",
-      "integrity": "sha512-KWAhBTB5GZrgFoL16rYvY6QI+MHUd5kQ++uFWpV8WE2/pF4RI2xiOTft7lfWUD+EARG9ygyRFbgtVO0RFlFOQw==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.0.3.tgz",
+      "integrity": "sha512-9lKoUZZitH134WxgfjGsYS8I2p5/e2bdwMCAtSuc31+a9Q/atpRSqStUSlsyumRxt781lgRdUvn9/jhGzTEoUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1775,9 +1775,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-16.4.0.tgz",
-      "integrity": "sha512-kS1IGkvUeOZeVUGs+fxSOzGqqXRwWL1dZq1Kq0KHo24gNZ/WqKi2cLVWpAAyQZA+P0dp82SG7WwZ+NZHhPYoSA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.0.3.tgz",
+      "integrity": "sha512-vE+DWFSlacnLOtHEhp5YS3q8Z0s0OQOBKYDvXG8g8fHyMGEQ2HFkE+WcIBe3LejQ39F2edh+y+vEs8xPgL8u0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1793,9 +1793,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-16.4.0.tgz",
-      "integrity": "sha512-/vx42EiKdt8E7oJ+pbTTKC+V9tgO7yiLKnHlXi664A/s4rEQOfJbB9wq4HYY2hmsDymGokKcNCJNOrdE8GwszA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.0.3.tgz",
+      "integrity": "sha512-KmcXC9mDB5a6aAYon+OP60ybRmfdlShu8EefEbkm+pL3+ZBvOBpaj0haHnCTD2sXBBiZCPqBsyIK6kuZSsVg0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1816,23 +1816,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-16.4.0.tgz",
-      "integrity": "sha512-XOVlNT6inumz2GLe70A5yuqRvEhGtXe2aCwtCuAnbkD5d1HH5G5NwSA374sF6Z+Kiy02s23eVfxOk+0oh2yQ6g==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.0.3.tgz",
+      "integrity": "sha512-QcDlgWoQdTkdt3CIINvQ+ZzKUJeYvPXq1s7AInPpqVHvkpmJAOkOst3lFDRNnLDcbW7HR3iynhzC54TqUNOqnw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-16.4.0.tgz",
-      "integrity": "sha512-ghI9uGpUyxPnJnVgKojf0RWTxGnNdmPz/JS4GdvHhw+Kl0cC2OQmvOKLDTSV423hj4WjaUBDqfdeAIZVMq0vLg==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.0.3.tgz",
+      "integrity": "sha512-LATOZfFUtuweBsCHJr8EpZv9CnKyFTKQ/JCPK8z3dHGXv/313pmGamN+N7qMioMXnzAL6M5OFRFpA2yBEU6euw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-16.4.0.tgz",
-      "integrity": "sha512-tVzMUV7vVy3H6M5kCgDxnL8EXRvDic0+GUb6fmzdsemU/HkA+zlKDbvKs9bfI79hX3EWeptFN2GOXnrGB84MbQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.0.3.tgz",
+      "integrity": "sha512-eXADQLKjL0eGvYItn0yKfZIGjnide4Su9emR7tsKTNsSHowEPX5IMfk+z90106xsR9G33kTutre2o94AOSihkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1840,9 +1840,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-16.4.0.tgz",
-      "integrity": "sha512-h0QVBtyzs0/ICLIDBDB1DFzmdvyCHfJB/AFxaonFJ7f6PIrUEFz/HjxvX8jMhcCllRxUrslWqF6DC9Gs76isVw==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.0.3.tgz",
+      "integrity": "sha512-HbcAuxZ/8ZltmOanAqqpqsmL5YZh6kOQZXcyEtH0Xl+xkRJlC3hS2KAEtWDANsHYZJsbM6S7fR4pdORcgiHcKg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@lerna/legacy-package-management": "^8.2.4",
-    "@lvce-editor/eslint-config": "^16.4.0",
+    "@lvce-editor/eslint-config": "^17.0.3",
     "@lvce-editor/eslint-plugin-github-actions": "^10.2.0",
     "eslint": "^10.7.0",
     "knip": "^6.20.0",

--- a/packages/extension-detail-view-worker/src/parts/FeatureRuntimeStatusVirtualDom/FeatureRuntimeStatusVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/FeatureRuntimeStatusVirtualDom/FeatureRuntimeStatusVirtualDom.ts
@@ -7,6 +7,12 @@ import * as GetActivationTimeVirtualDom from '../GetActivationTimeVirtualDom/Get
 import * as GetFeatureContentHeadingVirtualDom from '../GetFeatureContentHeadingVirtualDom/GetFeatureContentHeadingVirtualDom.ts'
 import * as GetStatusVirtualDom from '../GetStatusVirtualDom/GetStatusVirtualDom.ts'
 
+const featureContentNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.FeatureContent,
+  type: VirtualDomElements.Div,
+}
+
 const getChildCount = (status: number, activationTime: number, importTime: number): number => {
   let childCount = 0
   childCount += 2 // status
@@ -21,11 +27,7 @@ export const getRuntimeStatusVirtualDom = (state: FeatureRuntimeStatusState): re
   const heading = ExtensionDetailStrings.runtimeStatus()
   const childCount = getChildCount(status, displayedActivationTime, displayedImportTime)
   return [
-    {
-      childCount: 2,
-      className: ClassNames.FeatureContent,
-      type: VirtualDomElements.Div,
-    },
+    featureContentNode,
     ...GetFeatureContentHeadingVirtualDom.getFeatureContentHeadingVirtualDom(heading),
     {
       childCount,

--- a/packages/extension-detail-view-worker/src/parts/FeatureUnsupportedVirtualDom/FeatureUnsupportedVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/FeatureUnsupportedVirtualDom/FeatureUnsupportedVirtualDom.ts
@@ -3,21 +3,27 @@ import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDeta
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDetailStrings.ts'
 
+const unsupportedFeatureNode: VirtualDomNode = {
+  childCount: 2,
+  type: VirtualDomElements.Div,
+}
+
+const unsupportedFeatureHeadingNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.H1,
+}
+
+const unsupportedFeatureMessageNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.P,
+}
+
 export const getFeatureUnsupportedVirtualDom = (state: ExtensionDetailState): readonly VirtualDomNode[] => {
   return [
-    {
-      childCount: 2,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 1,
-      type: VirtualDomElements.H1,
-    },
+    unsupportedFeatureNode,
+    unsupportedFeatureHeadingNode,
     text(ExtensionDetailStrings.unsupportedFeature()),
-    {
-      childCount: 1,
-      type: VirtualDomElements.P,
-    },
+    unsupportedFeatureMessageNode,
     text(ExtensionDetailStrings.selectedFeatureUnknownOrUnsupported()),
   ]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetActivationTimeVirtualDom/GetActivationTimeVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetActivationTimeVirtualDom/GetActivationTimeVirtualDom.ts
@@ -3,6 +3,16 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDetailStrings.ts'
 import { formatTime } from '../FormatTime/FormatTime.ts'
 
+const definitionTermNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.Dt,
+}
+
+const definitionDescriptionNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.Dd,
+}
+
 export const getActivationTimeVirtualDom = (importTime: number, activationTime: number): readonly VirtualDomNode[] => {
   if (!activationTime && !importTime) {
     return []
@@ -10,25 +20,13 @@ export const getActivationTimeVirtualDom = (importTime: number, activationTime: 
   const formattedImportTime = formatTime(importTime)
   const formattedTime = formatTime(activationTime)
   return [
-    {
-      childCount: 1,
-      type: VirtualDomElements.Dt,
-    },
+    definitionTermNode,
     text(ExtensionDetailStrings.importTime()),
-    {
-      childCount: 1,
-      type: VirtualDomElements.Dd,
-    },
+    definitionDescriptionNode,
     text(formattedImportTime),
-    {
-      childCount: 1,
-      type: VirtualDomElements.Dt,
-    },
+    definitionTermNode,
     text(ExtensionDetailStrings.activationTime()),
-    {
-      childCount: 1,
-      type: VirtualDomElements.Dd,
-    },
+    definitionDescriptionNode,
     text(formattedTime),
   ]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetAdditionalDetailsEntryVirtualDom/GetAdditionalDetailsEntryVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetAdditionalDetailsEntryVirtualDom/GetAdditionalDetailsEntryVirtualDom.ts
@@ -3,23 +3,22 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const additionalDetailsEntryNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.AdditionalDetailsEntry,
+  type: VirtualDomElements.Div,
+}
+
+const additionalDetailsTitleNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.AdditionalDetailsTitle,
+  type: VirtualDomElements.Div,
+}
+
 export const getAdditionalDetailsEntryVirtualDom = <T>(
   heading: string,
   items: readonly T[],
   renderer: (items: readonly T[]) => readonly VirtualDomNode[],
 ): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 2,
-      className: ClassNames.AdditionalDetailsEntry,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 1,
-      className: ClassNames.AdditionalDetailsTitle,
-      type: VirtualDomElements.Div,
-    },
-    text(heading),
-    ...renderer(items),
-  ]
+  return [additionalDetailsEntryNode, additionalDetailsTitleNode, text(heading), ...renderer(items)]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetAdditionalDetailsVirtualDom/GetAdditionalDetailsVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetAdditionalDetailsVirtualDom/GetAdditionalDetailsVirtualDom.ts
@@ -11,6 +11,12 @@ import * as GetMoreInfoVirtualDom from '../GetMoreInfoVirtualDom/GetMoreInfoVirt
 import * as GetResourcesVirtualDom from '../GetResourcesVirtualDom/GetResourcesVirtualDom.ts'
 import * as TabIndex from '../TabIndex/TabIndex.ts'
 
+const asideNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.Aside,
+  type: VirtualDomElements.Aside,
+}
+
 export const getAdditionalDetailsVirtualDom = (
   showAdditionalDetails: boolean,
   firstHeading: string,
@@ -45,11 +51,7 @@ export const getAdditionalDetailsVirtualDom = (
   ]
   const childCount = 1 + (secondEntries.length > 0 ? 1 : 0) + (categories.length > 0 ? 1 : 0) + 1
   return [
-    {
-      childCount: 1,
-      className: ClassNames.Aside,
-      type: VirtualDomElements.Aside,
-    },
+    asideNode,
     {
       childCount: childCount,
       className: ClassNames.AdditionalDetails,

--- a/packages/extension-detail-view-worker/src/parts/GetCellCheckMarkVirtualDom/GetCellCheckMarkVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetCellCheckMarkVirtualDom/GetCellCheckMarkVirtualDom.ts
@@ -3,6 +3,12 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const tableCellNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.TableCell,
+  type: VirtualDomElements.Td,
+}
+
 const getCheckedText = (checked: boolean): string => {
   if (checked) {
     return 'yes'
@@ -13,12 +19,5 @@ const getCheckedText = (checked: boolean): string => {
 export const getCellCheckMarkVirtualDom = (value: string, props: { readonly checked: boolean }): readonly VirtualDomNode[] => {
   const { checked } = props
   const checkedText = getCheckedText(checked)
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.TableCell,
-      type: VirtualDomElements.Td,
-    },
-    text(checkedText),
-  ]
+  return [tableCellNode, text(checkedText)]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetCellCodeListVirtualDom/GetCellCodeListVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetCellCodeListVirtualDom/GetCellCodeListVirtualDom.ts
@@ -3,14 +3,13 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const codeNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.Code,
+}
+
 const getListItemDom = (item: string): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      type: VirtualDomElements.Code,
-    },
-    text(item),
-  ]
+  return [codeNode, text(item)]
 }
 
 export const getCellCodeListVirtualDom = (value: string, props: { readonly listItems: readonly string[] }): readonly VirtualDomNode[] => {

--- a/packages/extension-detail-view-worker/src/parts/GetCellCodeVirtualDom/GetCellCodeVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetCellCodeVirtualDom/GetCellCodeVirtualDom.ts
@@ -1,10 +1,16 @@
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const codeNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.Code,
+}
+
 export const getCellCodeVirtualDom = (value: string, props?: { readonly className?: string; readonly title?: string }): readonly VirtualDomNode[] => {
-  const tdClassName = props?.className ? `${ClassNames.TableCell} ${props.className}` : ClassNames.TableCell
+  const tdClassName = MergeClassNames.mergeClassNames(ClassNames.TableCell, props?.className || '')
   return [
     {
       childCount: 1,
@@ -12,10 +18,7 @@ export const getCellCodeVirtualDom = (value: string, props?: { readonly classNam
       type: VirtualDomElements.Td,
       ...(props?.title && { title: props.title }),
     },
-    {
-      childCount: 1,
-      type: VirtualDomElements.Code,
-    },
+    codeNode,
     text(value),
   ]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetCellLinkVirtualDom/GetCellLinkVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetCellLinkVirtualDom/GetCellLinkVirtualDom.ts
@@ -1,6 +1,7 @@
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
 interface TitleProps {
@@ -18,7 +19,7 @@ export const getCellLinkVirtualDom = (
   value: string,
   props?: { readonly className?: string; readonly title?: string; readonly href: string },
 ): readonly VirtualDomNode[] => {
-  const tdClassName = props?.className ? `${ClassNames.TableCell} ${props.className}` : ClassNames.TableCell
+  const tdClassName = MergeClassNames.mergeClassNames(ClassNames.TableCell, props?.className || '')
   return [
     {
       childCount: 1,

--- a/packages/extension-detail-view-worker/src/parts/GetCellTextVirtualDom/GetCellTextVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetCellTextVirtualDom/GetCellTextVirtualDom.ts
@@ -1,10 +1,11 @@
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
 export const getCellTextVirtualDom = (value: string, props?: { readonly className?: string; readonly title?: string }): readonly VirtualDomNode[] => {
-  const tdClassName = props?.className ? `${ClassNames.TableCell} ${props.className}` : ClassNames.TableCell
+  const tdClassName = MergeClassNames.mergeClassNames(ClassNames.TableCell, props?.className || '')
   return [
     {
       childCount: 1,

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailDescriptionVirtualDom/GetExtensionDetailDescriptionVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailDescriptionVirtualDom/GetExtensionDetailDescriptionVirtualDom.ts
@@ -2,13 +2,12 @@ import { VirtualDomElements, type VirtualDomNode } from '@lvce-editor/virtual-do
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const extensionDetailDescriptionNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.ExtensionDetailDescription,
+  type: VirtualDomElements.Div,
+}
+
 export const getExtensionDetailDescriptionVirtualDom = (description: string): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.ExtensionDetailDescription,
-      type: VirtualDomElements.Div,
-    },
-    text(description),
-  ]
+  return [extensionDetailDescriptionNode, text(description)]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailErrorVirtualDom/GetExtensionDetailErrorVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailErrorVirtualDom/GetExtensionDetailErrorVirtualDom.ts
@@ -3,6 +3,25 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 
+const extensionDetailErrorCardNode: VirtualDomNode = {
+  childCount: 3,
+  className: ClassNames.ExtensionDetailErrorCard,
+  role: AriaRoles.Alert,
+  type: VirtualDomElements.Div,
+}
+
+const extensionDetailErrorTitleNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.ExtensionDetailErrorTitle,
+  type: VirtualDomElements.H1,
+}
+
+const extensionDetailErrorMessageNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.ExtensionDetailErrorMessage,
+  type: VirtualDomElements.P,
+}
+
 export const getExtensionDetailErrorVirtualDom = (title: string, message: string): readonly VirtualDomNode[] => {
   return [
     {
@@ -10,28 +29,15 @@ export const getExtensionDetailErrorVirtualDom = (title: string, message: string
       className: MergeClassNames.mergeClassNames(ClassNames.Viewlet, ClassNames.ExtensionDetail, ClassNames.ExtensionDetailError),
       type: VirtualDomElements.Div,
     },
-    {
-      childCount: 3,
-      className: ClassNames.ExtensionDetailErrorCard,
-      role: AriaRoles.Alert,
-      type: VirtualDomElements.Div,
-    },
+    extensionDetailErrorCardNode,
     {
       childCount: 0,
       className: MergeClassNames.mergeClassNames(ClassNames.MaskIcon, ClassNames.MaskIconWarning, ClassNames.ExtensionDetailErrorIcon),
       type: VirtualDomElements.Div,
     },
-    {
-      childCount: 1,
-      className: ClassNames.ExtensionDetailErrorTitle,
-      type: VirtualDomElements.H1,
-    },
+    extensionDetailErrorTitleNode,
     text(title),
-    {
-      childCount: 1,
-      className: ClassNames.ExtensionDetailErrorMessage,
-      type: VirtualDomElements.P,
-    },
+    extensionDetailErrorMessageNode,
     text(message),
   ]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailHeaderVirtualDom/GetExtensionDetailHeaderVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailHeaderVirtualDom/GetExtensionDetailHeaderVirtualDom.ts
@@ -9,6 +9,12 @@ import { getExtensionDetailIconVirtualDom } from '../GetExtensionDetailIconVirtu
 import { getExtensionDetailMetadataVirtualDom } from '../GetExtensionDetailMetadataVirtualDom/GetExtensionDetailMetadataVirtualDom.ts'
 import { getExtensionDetailNameVirtualDom } from '../GetExtensionDetailNameVirtualDom/GetExtensionDetailNameVirtualDom.ts'
 
+const extensionDetailHeaderNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.ExtensionDetailHeader,
+  type: VirtualDomElements.Div,
+}
+
 export const getExtensionDetailHeaderVirtualDom = (
   name: string,
   iconSrc: string,
@@ -21,11 +27,7 @@ export const getExtensionDetailHeaderVirtualDom = (
 ): readonly VirtualDomNode[] => {
   const metadataDom = getExtensionDetailMetadataVirtualDom(downloadCount, rating)
   const dom = [
-    {
-      childCount: 2,
-      className: ClassNames.ExtensionDetailHeader,
-      type: VirtualDomElements.Div,
-    },
+    extensionDetailHeaderNode,
     getExtensionDetailIconVirtualDom(iconSrc),
     {
       childCount: metadataDom.length > 0 ? 4 : 3,

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailNameVirtualDom/GetExtensionDetailNameVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailNameVirtualDom/GetExtensionDetailNameVirtualDom.ts
@@ -3,31 +3,29 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import { getNameBadgeVirtualDom } from '../GetNameBadgeVirtualDom/GetNameBadgeVirtualDom.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const extensionDetailNameWithBadgeNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.ExtensionDetailName,
+  type: VirtualDomElements.Div,
+}
+
+const extensionDetailNameTextNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.Span,
+}
+
+const extensionDetailNameNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.ExtensionDetailName,
+  type: VirtualDomElements.Div,
+}
+
 const getExtensionDetailNameWithBadgeVirtualDom = (name: string, badge: string): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 2,
-      className: ClassNames.ExtensionDetailName,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 1,
-      type: VirtualDomElements.Span,
-    },
-    text(name),
-    ...getNameBadgeVirtualDom(badge),
-  ]
+  return [extensionDetailNameWithBadgeNode, extensionDetailNameTextNode, text(name), ...getNameBadgeVirtualDom(badge)]
 }
 
 const getExtensionDetailNameDefaultVirtualDom = (name: string): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.ExtensionDetailName,
-      type: VirtualDomElements.Div,
-    },
-    text(name),
-  ]
+  return [extensionDetailNameNode, text(name)]
 }
 
 export const getExtensionDetailNameVirtualDom = (name: string, badge: string): readonly VirtualDomNode[] => {

--- a/packages/extension-detail-view-worker/src/parts/GetFeatureActivationEventsVirtualDom/GetFeatureActivationEventsVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeatureActivationEventsVirtualDom/GetFeatureActivationEventsVirtualDom.ts
@@ -6,14 +6,16 @@ import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDeta
 import * as GetActivationEventVirtualDom from '../GetActivationEventVirtualDom/GetActivationEventVirtualDom.ts'
 import * as GetFeatureContentHeadingVirtualDom from '../GetFeatureContentHeadingVirtualDom/GetFeatureContentHeadingVirtualDom.ts'
 
+const featureContentNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.FeatureContent,
+  type: VirtualDomElements.Div,
+}
+
 export const getFeatureActivationEventsVirtualDom = (activationEvents: readonly ActivationEntry[]): readonly VirtualDomNode[] => {
   const heading = ExtensionDetailStrings.activationEvents()
   return [
-    {
-      childCount: 2,
-      className: ClassNames.FeatureContent,
-      type: VirtualDomElements.Div,
-    },
+    featureContentNode,
     ...GetFeatureContentHeadingVirtualDom.getFeatureContentHeadingVirtualDom(heading),
     {
       childCount: activationEvents.length,

--- a/packages/extension-detail-view-worker/src/parts/GetFeatureCommandsEmptyVirtualDom/GetFeatureCommandsEmptyVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeatureCommandsEmptyVirtualDom/GetFeatureCommandsEmptyVirtualDom.ts
@@ -4,20 +4,24 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDetailStrings.ts'
 import * as GetFeatureContentHeadingVirtualDom from '../GetFeatureContentHeadingVirtualDom/GetFeatureContentHeadingVirtualDom.ts'
 
+const featureContentNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.FeatureContent,
+  type: VirtualDomElements.Div,
+}
+
+const emptyCommandsNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.P,
+}
+
 export const getFeatureCommandsEmptyVirtualDom = (): readonly VirtualDomNode[] => {
   const heading = ExtensionDetailStrings.commands()
   const emptyCommandsArray = ExtensionDetailStrings.emptyCommandsArray()
   return [
-    {
-      childCount: 2,
-      className: ClassNames.FeatureContent,
-      type: VirtualDomElements.Div,
-    },
+    featureContentNode,
     ...GetFeatureContentHeadingVirtualDom.getFeatureContentHeadingVirtualDom(heading),
-    {
-      childCount: 1,
-      type: VirtualDomElements.P,
-    },
+    emptyCommandsNode,
     text(emptyCommandsArray),
   ]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetFeatureCommandsVirtualDom/GetFeatureCommandsVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeatureCommandsVirtualDom/GetFeatureCommandsVirtualDom.ts
@@ -8,6 +8,12 @@ import { getFeatureCommandsEmptyVirtualDom } from '../GetFeatureCommandsEmptyVir
 import * as GetFeatureContentHeadingVirtualDom from '../GetFeatureContentHeadingVirtualDom/GetFeatureContentHeadingVirtualDom.ts'
 import * as GetTableVirtualDom from '../GetTableVirtualDom/GetTableVirtualDom.ts'
 
+const featureContentNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.FeatureContent,
+  type: VirtualDomElements.Div,
+}
+
 // TODO have typed view-model
 export const getFeatureCommandsVirtualDom = (commands: readonly Row[]): readonly VirtualDomNode[] => {
   if (commands.length === 0) {
@@ -16,11 +22,7 @@ export const getFeatureCommandsVirtualDom = (commands: readonly Row[]): readonly
   const heading = ExtensionDetailStrings.commands()
   const tableInfo = GetCommandTableEntries.getCommandTableEntries(commands)
   return [
-    {
-      childCount: 2,
-      className: ClassNames.FeatureContent,
-      type: VirtualDomElements.Div,
-    },
+    featureContentNode,
     ...GetFeatureContentHeadingVirtualDom.getFeatureContentHeadingVirtualDom(heading),
     ...GetTableVirtualDom.getTableVirtualDom(tableInfo),
   ]

--- a/packages/extension-detail-view-worker/src/parts/GetFeatureContentHeadingVirtualDom/GetFeatureContentHeadingVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeatureContentHeadingVirtualDom/GetFeatureContentHeadingVirtualDom.ts
@@ -2,12 +2,11 @@ import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const featureContentHeadingNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.H1,
+}
+
 export const getFeatureContentHeadingVirtualDom = (heading: string): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      type: VirtualDomElements.H1,
-    },
-    text(heading),
-  ]
+  return [featureContentHeadingNode, text(heading)]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetFeatureNotImplementedVirtualDom/GetFeatureNotImplementedVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeatureNotImplementedVirtualDom/GetFeatureNotImplementedVirtualDom.ts
@@ -4,18 +4,18 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDetailStrings.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const featureContentNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.FeatureContent,
+  type: VirtualDomElements.Div,
+}
+
+const notImplementedHeadingNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.H1,
+}
+
 export const getFeatureNotImplementedVirtualDom = (): readonly VirtualDomNode[] => {
   const heading = ExtensionDetailStrings.notImplemented()
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.FeatureContent,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 1,
-      type: VirtualDomElements.H1,
-    },
-    text(heading),
-  ]
+  return [featureContentNode, notImplementedHeadingNode, text(heading)]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetFeatureProgrammingLanguagesVirtualDom/GetFeatureProgrammingLanguagesVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeatureProgrammingLanguagesVirtualDom/GetFeatureProgrammingLanguagesVirtualDom.ts
@@ -7,19 +7,23 @@ import * as GetFeatureContentHeadingVirtualDom from '../GetFeatureContentHeading
 import * as GetProgrammingLanguagesTableEntries from '../GetProgrammingLanguagesTableEntries/GetProgrammingLanguagesTableEntries.ts'
 import * as GetTableVirtualDom from '../GetTableVirtualDom/GetTableVirtualDom.ts'
 
+const featureContentNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.FeatureContent,
+  type: VirtualDomElements.Div,
+}
+
+const emptyProgrammingLanguagesNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.P,
+}
+
 export const getFeatureProgrammingLanguagesVirtualDom = (programmingLanguages: readonly Row[]): readonly VirtualDomNode[] => {
   const heading = ExtensionDetailStrings.programmingLanguages()
-  const top: readonly VirtualDomNode[] = [
-    {
-      childCount: 2,
-      className: ClassNames.FeatureContent,
-      type: VirtualDomElements.Div,
-    },
-    ...GetFeatureContentHeadingVirtualDom.getFeatureContentHeadingVirtualDom(heading),
-  ]
+  const top: readonly VirtualDomNode[] = [featureContentNode, ...GetFeatureContentHeadingVirtualDom.getFeatureContentHeadingVirtualDom(heading)]
 
   if (programmingLanguages.length === 0) {
-    return [...top, { childCount: 1, type: VirtualDomElements.P }, text('Empty Array.')]
+    return [...top, emptyProgrammingLanguagesNode, text('Empty Array.')]
   }
 
   const tableInfo = GetProgrammingLanguagesTableEntries.getProgrammingLanguagesTableEntries(programmingLanguages)

--- a/packages/extension-detail-view-worker/src/parts/GetFeatureSettingsVirtualDom/GetFeatureSettingsVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeatureSettingsVirtualDom/GetFeatureSettingsVirtualDom.ts
@@ -7,15 +7,17 @@ import * as GetFeatureContentHeadingVirtualDom from '../GetFeatureContentHeading
 import * as GetSettingsTableEntries from '../GetSettingsTableEntries/GetSettingsTableEntries.ts'
 import * as GetTableVirtualDom from '../GetTableVirtualDom/GetTableVirtualDom.ts'
 
+const featureContentNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.FeatureContent,
+  type: VirtualDomElements.Div,
+}
+
 export const getFeatureSettingsVirtualDom = (rows: readonly Row[]): readonly VirtualDomNode[] => {
   const heading = ExtensionDetailStrings.settings()
   const tableInfo = GetSettingsTableEntries.getSettingsTableEntries(rows)
   return [
-    {
-      childCount: 2,
-      className: ClassNames.FeatureContent,
-      type: VirtualDomElements.Div,
-    },
+    featureContentNode,
     ...GetFeatureContentHeadingVirtualDom.getFeatureContentHeadingVirtualDom(heading),
     ...GetTableVirtualDom.getTableVirtualDom(tableInfo),
   ]

--- a/packages/extension-detail-view-worker/src/parts/GetFeatureThemesVirtualDom/GetFeatureThemesVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeatureThemesVirtualDom/GetFeatureThemesVirtualDom.ts
@@ -5,15 +5,17 @@ import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDeta
 import * as GetFeatureContentHeadingVirtualDom from '../GetFeatureContentHeadingVirtualDom/GetFeatureContentHeadingVirtualDom.ts'
 import * as GetVirtualDomChildCount from '../GetVirtualDomChildCount/GetVirtualDomChildCount.ts'
 
+const featureContentNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.FeatureContent,
+  type: VirtualDomElements.Div,
+}
+
 export const getFeatureThemesVirtualDom = (themesDom: readonly VirtualDomNode[]): readonly VirtualDomNode[] => {
   const childCount = GetVirtualDomChildCount.getVirtualDomChildCount(themesDom)
   const heading = ExtensionDetailStrings.theme()
   return [
-    {
-      childCount: 2,
-      className: ClassNames.FeatureContent,
-      type: VirtualDomElements.Div,
-    },
+    featureContentNode,
     ...GetFeatureContentHeadingVirtualDom.getFeatureContentHeadingVirtualDom(heading),
     {
       childCount,

--- a/packages/extension-detail-view-worker/src/parts/GetFeatureWebViewsVirtualDom/GetFeatureWebViewsVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeatureWebViewsVirtualDom/GetFeatureWebViewsVirtualDom.ts
@@ -6,14 +6,16 @@ import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDeta
 import * as GetFeatureContentHeadingVirtualDom from '../GetFeatureContentHeadingVirtualDom/GetFeatureContentHeadingVirtualDom.ts'
 import * as GetWebViewVirtualDom from '../GetWebViewVirtualDom/GetWebViewVirtualDom.ts'
 
+const featureContentNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.FeatureContent,
+  type: VirtualDomElements.Div,
+}
+
 export const getFeatureWebViewsVirtualDom = (webViews: readonly WebView[]): readonly VirtualDomNode[] => {
   const heading = ExtensionDetailStrings.webViews()
   return [
-    {
-      childCount: 2,
-      className: ClassNames.FeatureContent,
-      type: VirtualDomElements.Div,
-    },
+    featureContentNode,
     ...GetFeatureContentHeadingVirtualDom.getFeatureContentHeadingVirtualDom(heading),
     {
       childCount: webViews.length,

--- a/packages/extension-detail-view-worker/src/parts/GetFeaturesEmptyVirtualDom/GetFeaturesEmptyVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeaturesEmptyVirtualDom/GetFeaturesEmptyVirtualDom.ts
@@ -4,14 +4,13 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDetailStrings.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const featuresNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.Features,
+  type: VirtualDomElements.Div,
+}
+
 export const getFeaturesEmptyVirtualDom = (): readonly VirtualDomNode[] => {
   const none = ExtensionDetailStrings.none()
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.Features,
-      type: VirtualDomElements.Div,
-    },
-    text(none),
-  ]
+  return [featuresNode, text(none)]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetFeaturesVirtualDom/GetFeaturesVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetFeaturesVirtualDom/GetFeaturesVirtualDom.ts
@@ -14,6 +14,12 @@ const sash: VirtualDomNode = {
   type: VirtualDomElements.Div,
 }
 
+const featuresNode: VirtualDomNode = {
+  childCount: 3,
+  className: ClassNames.Features,
+  type: VirtualDomElements.Div,
+}
+
 export const getFeaturesVirtualDom = (
   features: readonly Feature[],
   selectedFeature: string,
@@ -26,14 +32,5 @@ export const getFeaturesVirtualDom = (
   const fn = getFeatureVirtualDomHandler(selectedFeature)
   const featureVirtualDom = fn(state)
 
-  return [
-    {
-      childCount: 3,
-      className: ClassNames.Features,
-      type: VirtualDomElements.Div,
-    },
-    ...GetFeatureListVirtualDom.getFeatureListVirtualDom(features),
-    sash,
-    ...featureVirtualDom,
-  ]
+  return [featuresNode, ...GetFeatureListVirtualDom.getFeatureListVirtualDom(features), sash, ...featureVirtualDom]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetMarkdownImageErrorVirtualDom/GetMarkdownImageErrorVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetMarkdownImageErrorVirtualDom/GetMarkdownImageErrorVirtualDom.ts
@@ -3,13 +3,12 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDetailStrings.ts'
 
+const markdownImageErrorNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.MarkdownImageError,
+  type: VirtualDomElements.Span,
+}
+
 export const getMarkdownImageErrorVirtualDom = (): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.MarkdownImageError,
-      type: VirtualDomElements.Span,
-    },
-    text(ExtensionDetailStrings.imageCannotBeLoaded()),
-  ]
+  return [markdownImageErrorNode, text(ExtensionDetailStrings.imageCannotBeLoaded())]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetNameBadgeVirtualDom/GetNameBadgeVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetNameBadgeVirtualDom/GetNameBadgeVirtualDom.ts
@@ -2,16 +2,15 @@ import { VirtualDomElements, type VirtualDomNode } from '@lvce-editor/virtual-do
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const nameBadgeNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.ExtensionDetailNameBadge,
+  type: VirtualDomElements.Span,
+}
+
 export const getNameBadgeVirtualDom = (badge: string): readonly VirtualDomNode[] => {
   if (!badge) {
     return []
   }
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.ExtensionDetailNameBadge,
-      type: VirtualDomElements.Span,
-    },
-    text(badge),
-  ]
+  return [nameBadgeNode, text(badge)]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetNoReadmeVirtualDom/GetNoReadmeVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetNoReadmeVirtualDom/GetNoReadmeVirtualDom.ts
@@ -3,13 +3,12 @@ import { text, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDetailStrings.ts'
 
+const noReadmeNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.Markdown,
+  type: VirtualDomElements.Div,
+}
+
 export const getNoReadmeVirtualDom = (): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.Markdown,
-      type: VirtualDomElements.Div,
-    },
-    text(ExtensionDetailStrings.noReadmeFound()),
-  ]
+  return [noReadmeNode, text(ExtensionDetailStrings.noReadmeFound())]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetResourceLinkVirtualDom/GetResourceLinkVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetResourceLinkVirtualDom/GetResourceLinkVirtualDom.ts
@@ -5,16 +5,18 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const resourceIconNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.ResourceIcon,
+  type: VirtualDomElements.Div,
+}
+
 const getIconDom = (icon: string): readonly VirtualDomNode[] => {
   if (!icon) {
     return []
   }
   return [
-    {
-      childCount: 1,
-      className: ClassNames.ResourceIcon,
-      type: VirtualDomElements.Div,
-    },
+    resourceIconNode,
     {
       childCount: 0,
       className: mergeClassNames(ClassNames.MaskIcon, `MaskIcon${icon}`),

--- a/packages/extension-detail-view-worker/src/parts/GetSettingsButtonVirtualDom/GetSettingsButtonVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetSettingsButtonVirtualDom/GetSettingsButtonVirtualDom.ts
@@ -4,24 +4,25 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as InputName from '../InputName/InputName.ts'
 
+const settingsButtonNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.SettingsButton,
+  name: InputName.Settings,
+  onClick: DomEventListenerFunctions.HandleClickSettings,
+  title: 'Settings',
+  type: VirtualDomElements.Button,
+}
+
+const settingsIconNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.SettingsIcon,
+  text: '⚙️',
+  type: VirtualDomElements.Span,
+}
+
 export const getSettingsButtonVirtualDom = (enabled: boolean): readonly VirtualDomNode[] => {
   if (!enabled) {
     return []
   }
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.SettingsButton,
-      name: InputName.Settings,
-      onClick: DomEventListenerFunctions.HandleClickSettings,
-      title: 'Settings',
-      type: VirtualDomElements.Button,
-    },
-    {
-      childCount: 0,
-      className: ClassNames.SettingsIcon,
-      text: '⚙️',
-      type: VirtualDomElements.Span,
-    },
-  ]
+  return [settingsButtonNode, settingsIconNode]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetTableHeadingVirtualDom/GetTableHeadingVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetTableHeadingVirtualDom/GetTableHeadingVirtualDom.ts
@@ -3,13 +3,12 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const tableHeadingNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.TableHeading,
+  type: VirtualDomElements.Th,
+}
+
 export const getTableHeadingVirtualDom = (heading: string): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.TableHeading,
-      type: VirtualDomElements.Th,
-    },
-    text(heading),
-  ]
+  return [tableHeadingNode, text(heading)]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetTableVirtualDom/GetTableVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetTableVirtualDom/GetTableVirtualDom.ts
@@ -5,18 +5,22 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as GetTableHeadingVirtualDom from '../GetTableHeadingVirtualDom/GetTableHeadingVirtualDom.ts'
 import * as GetTableRowVirtualDom from '../GetTableRowVirtualDom/GetTableRowVirtualDom.ts'
 
+const tableNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.Table,
+  type: VirtualDomElements.Table,
+}
+
+const tableHeadNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.THead,
+}
+
 export const getTableVirtualDom = (tableInfo: TableInfo): readonly VirtualDomNode[] => {
   const { headings, rows } = tableInfo
   return [
-    {
-      childCount: 2,
-      className: ClassNames.Table,
-      type: VirtualDomElements.Table,
-    },
-    {
-      childCount: 1,
-      type: VirtualDomElements.THead,
-    },
+    tableNode,
+    tableHeadNode,
     {
       childCount: headings.length,
       type: VirtualDomElements.Tr,

--- a/packages/extension-detail-view-worker/src/parts/GetWebViewVirtualDom/GetWebViewVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetWebViewVirtualDom/GetWebViewVirtualDom.ts
@@ -23,6 +23,12 @@ const item: VirtualDomNode = {
   type: VirtualDomElements.Div,
 }
 
+const featureWebViewNode: VirtualDomNode = {
+  childCount: 4,
+  className: ClassNames.FeatureWebView,
+  type: VirtualDomElements.Div,
+}
+
 export const getWebViewVirtualDom = (webView: WebView): readonly VirtualDomNode[] => {
   const { contentSecurityPolicyString, elementsString, id, selectorString } = webView
   const textId = ExtensionDetailStrings.id()
@@ -30,11 +36,7 @@ export const getWebViewVirtualDom = (webView: WebView): readonly VirtualDomNode[
   const textContentSecurityPolicy = ExtensionDetailStrings.contentSecurityPolicy()
   const textElements = ExtensionDetailStrings.elements()
   return [
-    {
-      childCount: 4,
-      className: ClassNames.FeatureWebView,
-      type: VirtualDomElements.Div,
-    },
+    featureWebViewNode,
     item,
     heading,
     text(textId),

--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 580_000
+export const threshold = 585_000
 
 export const instantiations = 16000
 


### PR DESCRIPTION
Update ESLint and the shared config, hoist static extension-detail virtual DOM nodes, and use the class-name merge helper required by the latest lint rules. Adjust the worker memory ceiling by 5 KB for the retained nodes.