### PR TITLE
feature: cache changelog content

### DIFF
--- a/packages/extension-detail-view-worker/src/parts/ChangelogCache/ChangelogCache.ts
+++ b/packages/extension-detail-view-worker/src/parts/ChangelogCache/ChangelogCache.ts
@@ -1,0 +1,51 @@
+import { getCache, type ICache } from '../GetCache/GetCache.ts'
+
+const bucketName = 'changelog-cache'
+const cacheName = 'lvce-editor/changelog-cache'
+const cachedAtHeader = 'X-Lvce-Editor-Cached-At'
+const maxAge = 60 * 60 * 1000
+
+type GetCache = (cacheName: string, bucketName: string) => Promise<ICache>
+
+const getCacheKey = (uri: string): string => {
+  return `https://-/changelog/${encodeURIComponent(uri)}`
+}
+
+const isFresh = (cachedAt: number, now: number): boolean => {
+  return Number.isFinite(cachedAt) && now - cachedAt <= maxAge
+}
+
+export const get = async (uri: string, now: number = Date.now(), getCacheFunction: GetCache = getCache): Promise<string | undefined> => {
+  try {
+    const cache = await getCacheFunction(cacheName, bucketName)
+    const response = await cache.match(getCacheKey(uri))
+    if (!response) {
+      return undefined
+    }
+    const cachedAt = Number(response.headers.get(cachedAtHeader))
+    if (!isFresh(cachedAt, now)) {
+      return undefined
+    }
+    return response.text()
+  } catch {
+    return undefined
+  }
+}
+
+export const set = async (uri: string, value: string, now: number = Date.now(), getCacheFunction: GetCache = getCache): Promise<void> => {
+  try {
+    const cache = await getCacheFunction(cacheName, bucketName)
+    await cache.put(
+      getCacheKey(uri),
+      new Response(value, {
+        headers: {
+          [cachedAtHeader]: `${now}`,
+          'Content-Length': `${value.length}`,
+          'Content-Type': 'application/markdown',
+        },
+      }),
+    )
+  } catch {
+    return
+  }
+}

--- a/packages/extension-detail-view-worker/src/parts/LoadChangelogContent/LoadChangelogContent.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadChangelogContent/LoadChangelogContent.ts
@@ -1,13 +1,24 @@
 import { VError } from '@lvce-editor/verror'
+import * as ChangelogCache from '../ChangelogCache/ChangelogCache.ts'
 import * as FileSystem from '../FileSystem/FileSystem.ts'
 import * as IsEnoentError from '../IsEnoentError/IsEnoentError.ts'
 import * as Logger from '../Logger/Logger.ts'
 import * as Path from '../Path/Path.ts'
 
-export const loadChangelogContent = async (path: string): Promise<string> => {
+interface IChangelogCache {
+  readonly get: (uri: string) => Promise<string | undefined>
+  readonly set: (uri: string, value: string) => Promise<void>
+}
+
+export const loadChangelogContent = async (path: string, cache: IChangelogCache = ChangelogCache): Promise<string> => {
   try {
     const changelogUrl = Path.join(path, 'CHANGELOG.md')
+    const cachedContent = await cache.get(changelogUrl)
+    if (cachedContent !== undefined) {
+      return cachedContent
+    }
     const changelogContent = await FileSystem.readFile(changelogUrl)
+    await cache.set(changelogUrl, changelogContent)
     return changelogContent
   } catch (error) {
     if (IsEnoentError.isEnoentError(error)) {

--- a/packages/extension-detail-view-worker/test/ChangelogCache.test.ts
+++ b/packages/extension-detail-view-worker/test/ChangelogCache.test.ts
@@ -1,0 +1,92 @@
+import { expect, jest, test } from '@jest/globals'
+import type { ICache } from '../src/parts/GetCache/GetCache.ts'
+import * as ChangelogCache from '../src/parts/ChangelogCache/ChangelogCache.ts'
+
+const uri = 'https://example.com/extensions/test.extension/CHANGELOG.md'
+const cacheKey = `https://-/changelog/${encodeURIComponent(uri)}`
+const now = 10_000_000
+
+const createCache = (response: Response | undefined): ICache => {
+  return {
+    match: jest.fn<(request: RequestInfo | URL) => Promise<Response | undefined>>().mockResolvedValue(response),
+    put: jest.fn<(request: RequestInfo | URL, response: Response) => Promise<void>>().mockResolvedValue(undefined),
+  }
+}
+
+const createResponse = (value: string, cachedAt: number | string): Response => {
+  return new Response(value, {
+    headers: {
+      'X-Lvce-Editor-Cached-At': `${cachedAt}`,
+    },
+  })
+}
+
+test('get returns undefined when the cache entry does not exist', async () => {
+  const cache = createCache(undefined)
+
+  const result = await ChangelogCache.get(uri, now, async () => cache)
+
+  expect(result).toBeUndefined()
+  expect(cache.match).toHaveBeenCalledWith(cacheKey)
+})
+
+test('get returns content cached less than one hour ago', async () => {
+  const cache = createCache(createResponse('# Changelog', now - 30 * 60 * 1000))
+
+  const result = await ChangelogCache.get(uri, now, async () => cache)
+
+  expect(result).toBe('# Changelog')
+})
+
+test('get returns content cached exactly one hour ago', async () => {
+  const cache = createCache(createResponse('# Changelog', now - 60 * 60 * 1000))
+
+  const result = await ChangelogCache.get(uri, now, async () => cache)
+
+  expect(result).toBe('# Changelog')
+})
+
+test('get returns undefined when the cache entry is more than one hour old', async () => {
+  const cache = createCache(createResponse('# Stale changelog', now - 60 * 60 * 1000 - 1))
+
+  const result = await ChangelogCache.get(uri, now, async () => cache)
+
+  expect(result).toBeUndefined()
+})
+
+test('get returns undefined when the cache timestamp is invalid', async () => {
+  const cache = createCache(createResponse('# Changelog', 'invalid'))
+
+  const result = await ChangelogCache.get(uri, now, async () => cache)
+
+  expect(result).toBeUndefined()
+})
+
+test('get returns undefined when cache storage fails', async () => {
+  const result = await ChangelogCache.get(uri, now, async () => {
+    throw new Error('cache unavailable')
+  })
+
+  expect(result).toBeUndefined()
+})
+
+test('set stores the content and cache timestamp', async () => {
+  const cache = createCache(undefined)
+
+  await ChangelogCache.set(uri, '# Changelog', now, async () => cache)
+
+  expect(cache.put).toHaveBeenCalledTimes(1)
+  const [key, response] = (cache.put as jest.MockedFunction<ICache['put']>).mock.calls[0]
+  expect(key).toBe(cacheKey)
+  expect(response.headers.get('X-Lvce-Editor-Cached-At')).toBe(`${now}`)
+  expect(response.headers.get('Content-Type')).toBe('application/markdown')
+  expect(await response.text()).toBe('# Changelog')
+})
+
+test('set ignores cache storage failures', async () => {
+  await expect(
+    ChangelogCache.set(uri, '# Changelog', now, async () => {
+      throw new Error('cache unavailable')
+    }),
+  ).resolves.toBeUndefined()
+})

--- a/packages/extension-detail-view-worker/test/LoadChangelogContent.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadChangelogContent.test.ts
@@ -16,6 +16,44 @@ test('loadChangelogContent successfully loads changelog', async () => {
   expect(mockRpc.invocations).toEqual([['FileSystem.readFile', '/test/extension/CHANGELOG.md']])
 })
 
+test('loadChangelogContent uses cached content without reading the file', async () => {
+  const cache = {
+    get: jest.fn<(uri: string) => Promise<string | undefined>>().mockResolvedValue('# Cached changelog'),
+    set: jest.fn<(uri: string, value: string) => Promise<void>>(),
+  }
+  using mockRpc = FileSystemWorker.registerMockRpc({
+    'FileSystem.readFile': () => {
+      throw new Error('unexpected read')
+    },
+  })
+
+  const result = await LoadChangelogContent.loadChangelogContent('/test/extension', cache)
+
+  expect(result).toBe('# Cached changelog')
+  expect(cache.get).toHaveBeenCalledWith('/test/extension/CHANGELOG.md')
+  expect(cache.set).not.toHaveBeenCalled()
+  expect(mockRpc.invocations).toEqual([])
+})
+
+test('loadChangelogContent caches content after reading the file', async () => {
+  const cache = {
+    get: jest.fn<(uri: string) => Promise<string | undefined>>().mockResolvedValue(undefined),
+    set: jest.fn<(uri: string, value: string) => Promise<void>>().mockResolvedValue(undefined),
+  }
+  using mockRpc = FileSystemWorker.registerMockRpc({
+    'FileSystem.readFile': () => {
+      return '# Network changelog'
+    },
+  })
+
+  const result = await LoadChangelogContent.loadChangelogContent('/test/extension', cache)
+
+  expect(result).toBe('# Network changelog')
+  expect(cache.get).toHaveBeenCalledWith('/test/extension/CHANGELOG.md')
+  expect(cache.set).toHaveBeenCalledWith('/test/extension/CHANGELOG.md', '# Network changelog')
+  expect(mockRpc.invocations).toEqual([['FileSystem.readFile', '/test/extension/CHANGELOG.md']])
+})
+
 test('loadChangelogContent returns empty string when file not found', async () => {
   const enoentError = new Error('File not found')
   ;(enoentError as any).code = ErrorCodes.ENOENT


### PR DESCRIPTION
Cache extension changelog content in Cache Storage for one hour.

Fresh cached changelogs now load without another file-system or GitHub request, while stale entries refresh from the source.