### PR TITLE
feature: format changelog publication time relatively

### DIFF
--- a/packages/e2e/src/extension-detail.changelog-github-one-release.ts
+++ b/packages/e2e/src/extension-detail.changelog-github-one-release.ts
@@ -2,7 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 import { createRelease, openGithubChangelog } from './_GithubReleaseTest.js'
 
 export const test: Test = async (api) => {
-  await openGithubChangelog(api, { body: [createRelease()], type: 'success' })
+  const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString()
+  await openGithubChangelog(api, { body: [createRelease({ published_at: twoDaysAgo })], type: 'success' })
   await api.expect(api.Locator('.Changelog')).toContainText('Version 1.0.0')
+  await api.expect(api.Locator('.Changelog')).toContainText('Published 2 days ago')
   await api.expect(api.Locator('.Changelog')).toContainText('Fixed an important bug.')
 }

--- a/packages/extension-detail-view-worker/src/parts/GetGithubReleasesMarkdown/GetGithubReleasesMarkdown.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetGithubReleasesMarkdown/GetGithubReleasesMarkdown.ts
@@ -1,11 +1,12 @@
 import type { GithubRelease } from '../GithubRelease/GithubRelease.ts'
 import type { GithubRepository } from '../GithubRepository/GithubRepository.ts'
+import * as FormatCreated from '../FormatCreated/FormatCreated.ts'
 
 const escapeMarkdown = (value: string): string => {
   return value.replaceAll('\\', '\\\\').replaceAll('[', '\\[').replaceAll(']', '\\]')
 }
 
-const getPublishedText = (publishedAt: string): string => {
+const getPublishedText = (publishedAt: string, now: number): string => {
   if (!publishedAt) {
     return 'Publication date unavailable'
   }
@@ -13,10 +14,14 @@ const getPublishedText = (publishedAt: string): string => {
   if (Number.isNaN(date.getTime())) {
     return 'Publication date unavailable'
   }
-  return `Published ${date.toLocaleDateString(undefined, { dateStyle: 'long' })}`
+  return `Published ${FormatCreated.formatCreated(date.getTime(), now)}`
 }
 
-export const getGithubReleasesMarkdown = (releases: readonly GithubRelease[], githubRepository: GithubRepository): string => {
+export const getGithubReleasesMarkdown = (
+  releases: readonly GithubRelease[],
+  githubRepository: GithubRepository,
+  now: number = Date.now(),
+): string => {
   if (releases.length === 0) {
     return `# Changelog\n\nNo GitHub releases were found for **${escapeMarkdown(githubRepository.owner)}/${escapeMarkdown(githubRepository.repository)}**.`
   }
@@ -24,7 +29,7 @@ export const getGithubReleasesMarkdown = (releases: readonly GithubRelease[], gi
     .map((release) => {
       const title = release.name || release.tagName
       const body = release.body.trim() || '_No release notes were provided._'
-      return `# [${escapeMarkdown(title)}](${release.htmlUrl})\n\n${getPublishedText(release.publishedAt)} · \`${release.tagName}\`\n\n${body}`
+      return `# [${escapeMarkdown(title)}](${release.htmlUrl})\n\n${getPublishedText(release.publishedAt, now)} · \`${release.tagName}\`\n\n${body}`
     })
     .join('\n\n---\n\n')
 }

--- a/packages/extension-detail-view-worker/test/GetGithubReleasesMarkdown.test.ts
+++ b/packages/extension-detail-view-worker/test/GetGithubReleasesMarkdown.test.ts
@@ -16,8 +16,10 @@ test('renders an empty releases message', () => {
 })
 
 test('renders release metadata and body markdown', () => {
-  const result = getGithubReleasesMarkdown([release], repository)
+  const now = new Date('2026-01-04T03:04:05Z').getTime()
+  const result = getGithubReleasesMarkdown([release], repository, now)
   expect(result).toContain('# [Version \\[1.0.0\\]](https://github.com/test-owner/test-repository/releases/tag/v1.0.0)')
+  expect(result).toContain('Published 2 days ago')
   expect(result).toContain('`v1.0.0`')
   expect(result).toContain('**Important** fix')
 })


### PR DESCRIPTION
Formats GitHub release publication dates in the extension detail changelog as relative times such as "Published 2 days ago". Adds unit and end-to-end regression coverage for the rendered text.