### PR TITLE
fix: show accurate extension runtime status

### DIFF
--- a/packages/e2e/fixtures/extension-runtime-status/extension.json
+++ b/packages/e2e/fixtures/extension-runtime-status/extension.json
@@ -2,7 +2,7 @@
   "id": "test.runtime-status",
   "name": "Runtime Status Test",
   "description": "Runtime Status Test",
-  "main": "index.js",
+  "browser": "index.js",
   "activation": ["onCommand:runtimeStatus.activate"],
   "commands": [
     {

--- a/packages/e2e/fixtures/extension-runtime-status/extension.json
+++ b/packages/e2e/fixtures/extension-runtime-status/extension.json
@@ -1,12 +1,13 @@
 {
-  "id": "test.commands-test",
-  "name": "Test Commands",
-  "description": "Test Commands",
+  "id": "test.runtime-status",
+  "name": "Runtime Status Test",
+  "description": "Runtime Status Test",
   "main": "index.js",
+  "activation": ["onCommand:runtimeStatus.activate"],
   "commands": [
     {
-      "id": "test",
-      "label": "Test"
+      "id": "runtimeStatus.activate",
+      "label": "Activate Runtime Status Test"
     }
   ]
 }

--- a/packages/e2e/fixtures/extension-runtime-status/index.js
+++ b/packages/e2e/fixtures/extension-runtime-status/index.js
@@ -1,1 +1,9 @@
-export const activate = () => {}
+export const activate = async () => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 20)
+  })
+  vscode.registerCommand({
+    id: 'runtimeStatus.activate',
+    execute() {},
+  })
+}

--- a/packages/e2e/src/extension-detail.feature-activated-runtime-status.ts
+++ b/packages/e2e/src/extension-detail.feature-activated-runtime-status.ts
@@ -1,6 +1,6 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'extension-detail.feature-runtime-status'
+export const name = 'extension-detail.feature-activated-runtime-status'
 
 export const test: Test = async ({ Command, expect, Extension, ExtensionDetail, Locator }) => {
   // arrange

--- a/packages/e2e/src/extension-detail.feature-runtime-status.ts
+++ b/packages/e2e/src/extension-detail.feature-runtime-status.ts
@@ -2,11 +2,12 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'extension-detail.feature-runtime-status'
 
-export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+export const test: Test = async ({ Command, expect, Extension, ExtensionDetail, Locator }) => {
   // arrange
   const extensionUri = import.meta.resolve('../fixtures/extension-runtime-status')
   await Extension.addWebExtension(extensionUri)
-  await ExtensionDetail.open('test.commands-test')
+  await Command.executeExtensionCommand('runtimeStatus.activate')
+  await ExtensionDetail.open('test.runtime-status')
   await ExtensionDetail.selectFeatures()
 
   // act
@@ -17,5 +18,7 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await expect(heading).toBeVisible()
   await expect(heading).toHaveText('Runtime Status')
   const definitionList = Locator('.FeatureContent dl')
-  await expect(definitionList).toHaveText(`Status: none`)
+  await expect(definitionList).toContainText('Status: activated')
+  await expect(definitionList).toContainText('Activation Event: onCommand:runtimeStatus.activate')
+  await expect(definitionList).toContainText('Activation Time: ')
 }

--- a/packages/e2e/src/extension-detail.feature-runtime-status.ts
+++ b/packages/e2e/src/extension-detail.feature-runtime-status.ts
@@ -6,7 +6,7 @@ export const test: Test = async ({ Command, expect, Extension, ExtensionDetail, 
   // arrange
   const extensionUri = import.meta.resolve('../fixtures/extension-runtime-status')
   await Extension.addWebExtension(extensionUri)
-  await Command.executeExtensionCommand('runtimeStatus.activate')
+  await Command.execute('ExtensionHostManagement.activateByEvent', 'onCommand:runtimeStatus.activate', '', 2)
   await ExtensionDetail.open('test.runtime-status')
   await ExtensionDetail.selectFeatures()
 

--- a/packages/extension-detail-view-worker/src/parts/ExtensionDetailStrings/ExtensionDetailStrings.ts
+++ b/packages/extension-detail-view-worker/src/parts/ExtensionDetailStrings/ExtensionDetailStrings.ts
@@ -109,6 +109,10 @@ export const activationEvents = (): string => {
   return I18nString.i18nString(UiStrings.ActivationEvents)
 }
 
+export const activationEvent = (): string => {
+  return I18nString.i18nString(UiStrings.ActivationEvent)
+}
+
 export const runtimeStatus = (): string => {
   return I18nString.i18nString(UiStrings.RuntimeStatus)
 }

--- a/packages/extension-detail-view-worker/src/parts/ExtensionHostWorker/ExtensionHostWorker.ts
+++ b/packages/extension-detail-view-worker/src/parts/ExtensionHostWorker/ExtensionHostWorker.ts
@@ -1,3 +1,3 @@
 import { ExtensionHost } from '@lvce-editor/rpc-registry'
 
-export const { getRuntimeStatus, registerMockRpc, set } = ExtensionHost as any
+export const { set } = ExtensionHost as any

--- a/packages/extension-detail-view-worker/src/parts/FeatureRuntimeStatusVirtualDom/FeatureRuntimeStatusVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/FeatureRuntimeStatusVirtualDom/FeatureRuntimeStatusVirtualDom.ts
@@ -5,6 +5,7 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDetailStrings.ts'
 import * as GetActivationTimeVirtualDom from '../GetActivationTimeVirtualDom/GetActivationTimeVirtualDom.ts'
 import * as GetFeatureContentHeadingVirtualDom from '../GetFeatureContentHeadingVirtualDom/GetFeatureContentHeadingVirtualDom.ts'
+import * as GetRuntimeActivationEventVirtualDom from '../GetRuntimeActivationEventVirtualDom/GetRuntimeActivationEventVirtualDom.ts'
 import * as GetStatusVirtualDom from '../GetStatusVirtualDom/GetStatusVirtualDom.ts'
 
 const featureContentNode: VirtualDomNode = {
@@ -13,9 +14,12 @@ const featureContentNode: VirtualDomNode = {
   type: VirtualDomElements.Div,
 }
 
-const getChildCount = (status: number, activationTime: number, importTime: number): number => {
+const getChildCount = (status: number, activationEvent: string, activationTime: number, importTime: number): number => {
   let childCount = 0
   childCount += 2 // status
+  if (activationEvent) {
+    childCount += 2
+  }
   if (importTime || activationTime) {
     childCount += 4
   }
@@ -23,9 +27,9 @@ const getChildCount = (status: number, activationTime: number, importTime: numbe
 }
 
 export const getRuntimeStatusVirtualDom = (state: FeatureRuntimeStatusState): readonly VirtualDomNode[] => {
-  const { activationTime: displayedImportTime, importTime: displayedActivationTime, status } = state
+  const { activationTime, importTime, status, wasActivatedByEvent } = state
   const heading = ExtensionDetailStrings.runtimeStatus()
-  const childCount = getChildCount(status, displayedActivationTime, displayedImportTime)
+  const childCount = getChildCount(status, wasActivatedByEvent, activationTime, importTime)
   return [
     featureContentNode,
     ...GetFeatureContentHeadingVirtualDom.getFeatureContentHeadingVirtualDom(heading),
@@ -35,6 +39,7 @@ export const getRuntimeStatusVirtualDom = (state: FeatureRuntimeStatusState): re
       type: VirtualDomElements.Dl,
     },
     ...GetStatusVirtualDom.getStatusVirtualDom(status),
-    ...GetActivationTimeVirtualDom.getActivationTimeVirtualDom(displayedImportTime, displayedActivationTime),
+    ...GetRuntimeActivationEventVirtualDom.getRuntimeActivationEventVirtualDom(wasActivatedByEvent),
+    ...GetActivationTimeVirtualDom.getActivationTimeVirtualDom(importTime, activationTime),
   ]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetRuntimeActivationEventVirtualDom/GetRuntimeActivationEventVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetRuntimeActivationEventVirtualDom/GetRuntimeActivationEventVirtualDom.ts
@@ -1,0 +1,27 @@
+import { text, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
+import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDetailStrings.ts'
+
+const key: VirtualDomNode = {
+  childCount: 1,
+  className: 'RuntimeStatusDefinitionListKey',
+  type: VirtualDomElements.Dt,
+}
+
+const value: VirtualDomNode = {
+  childCount: 1,
+  className: 'RuntimeStatusDefinitionListValue',
+  type: VirtualDomElements.Dd,
+}
+
+const code: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.Code,
+}
+
+export const getRuntimeActivationEventVirtualDom = (activationEvent: string): readonly VirtualDomNode[] => {
+  if (!activationEvent) {
+    return []
+  }
+  return [key, text(`${ExtensionDetailStrings.activationEvent()}: `), value, code, text(activationEvent)]
+}

--- a/packages/extension-detail-view-worker/src/parts/GetRuntimeStatus/GetRuntimeStatus.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetRuntimeStatus/GetRuntimeStatus.ts
@@ -1,9 +1,6 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import type { RuntimeStatus } from '../RuntimeStatus/RuntimeStatus.ts'
-import * as ExtensionHostWorker from '../ExtensionHostWorker/ExtensionHostWorker.ts'
 
 export const getRuntimeStatus = async (extensionId: string): Promise<RuntimeStatus> => {
-  // @ts-ignore
-  const status = await ExtensionHostWorker.getRuntimeStatus(extensionId)
-  // @ts-ignore
-  return status
+  return ExtensionManagementWorker.invoke('Extensions.getRuntimeStatus', extensionId)
 }

--- a/packages/extension-detail-view-worker/src/parts/UiStrings/UiStrings.ts
+++ b/packages/extension-detail-view-worker/src/parts/UiStrings/UiStrings.ts
@@ -1,4 +1,5 @@
 export const ActivationEvents = 'Activation Events'
+export const ActivationEvent = 'Activation Event'
 export const ActivationTime = 'Activation Time: '
 export const Categories = 'Categories'
 export const Changelog = 'Changelog'

--- a/packages/extension-detail-view-worker/test/ExtensionDetailStrings.test.ts
+++ b/packages/extension-detail-view-worker/test/ExtensionDetailStrings.test.ts
@@ -201,6 +201,10 @@ test('activationTime returns correct i18n string', () => {
   expect(ExtensionDetailStrings.activationTime()).toBe('Activation Time: ')
 })
 
+test('activationEvent returns correct i18n string', () => {
+  expect(ExtensionDetailStrings.activationEvent()).toBe('Activation Event')
+})
+
 test('unsupportedFeature returns correct i18n string', () => {
   expect(ExtensionDetailStrings.unsupportedFeature()).toBe('Unsupported Feature')
 })

--- a/packages/extension-detail-view-worker/test/FeatureRuntimeStatusDetails.test.ts
+++ b/packages/extension-detail-view-worker/test/FeatureRuntimeStatusDetails.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from '@jest/globals'
+import { expect, test } from '@jest/globals'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import type { RuntimeStatus } from '../src/parts/RuntimeStatus/RuntimeStatus.ts'
-import * as ExtensionHostWorker from '../src/parts/ExtensionHostWorker/ExtensionHostWorker.ts'
 import { getRuntimeStatusDetails } from '../src/parts/FeatureRuntimeStatusDetails/FeatureRuntimeStatusDetails.ts'
 import * as RuntimeStatusType from '../src/parts/RuntimeStatusType/RuntimeStatusType.ts'
 
@@ -13,8 +13,8 @@ test('getRuntimeStatusDetails should return runtime status details for extension
     status: RuntimeStatusType.Activated,
   }
 
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       return mockRuntimeStatus
     },
   })
@@ -32,7 +32,7 @@ test('getRuntimeStatusDetails should return runtime status details for extension
     status: RuntimeStatusType.Activated,
     wasActivatedByEvent: 'onStartupFinished',
   })
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'test-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'test-extension']])
 })
 
 test('getRuntimeStatusDetails should handle different activation events', async () => {
@@ -44,8 +44,8 @@ test('getRuntimeStatusDetails should handle different activation events', async 
     status: RuntimeStatusType.Activating,
   }
 
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       return mockRuntimeStatus
     },
   })
@@ -63,7 +63,7 @@ test('getRuntimeStatusDetails should handle different activation events', async 
     status: RuntimeStatusType.Activating,
     wasActivatedByEvent: 'onCommand:test.command',
   })
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'another-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'another-extension']])
 })
 
 test('getRuntimeStatusDetails should handle error status', async () => {
@@ -75,8 +75,8 @@ test('getRuntimeStatusDetails should handle error status', async () => {
     status: RuntimeStatusType.Error,
   }
 
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       return mockRuntimeStatus
     },
   })
@@ -94,12 +94,12 @@ test('getRuntimeStatusDetails should handle error status', async () => {
     status: RuntimeStatusType.Error,
     wasActivatedByEvent: '',
   })
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'error-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'error-extension']])
 })
 
 test('getRuntimeStatusDetails should propagate errors from getRuntimeStatus', async () => {
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       throw new Error('Runtime status error')
     },
   })
@@ -110,5 +110,5 @@ test('getRuntimeStatusDetails should propagate errors from getRuntimeStatus', as
   }
 
   await expect(getRuntimeStatusDetails(extension)).rejects.toThrow('Runtime status error')
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'failing-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'failing-extension']])
 })

--- a/packages/extension-detail-view-worker/test/FeatureRuntimeStatusVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/FeatureRuntimeStatusVirtualDom.test.ts
@@ -71,7 +71,7 @@ test('getRuntimeStatusVirtualDom should return correct virtual DOM structure wit
   })
   expect(result[11]).toEqual({
     childCount: 0,
-    text: '150.75ms',
+    text: '0.00ms',
     type: VirtualDomElements.Text,
   })
   expect(result[12]).toEqual({
@@ -89,7 +89,30 @@ test('getRuntimeStatusVirtualDom should return correct virtual DOM structure wit
   })
   expect(result[15]).toEqual({
     childCount: 0,
-    text: '0.00ms',
+    text: '150.75ms',
+    type: VirtualDomElements.Text,
+  })
+})
+
+test('getRuntimeStatusVirtualDom should render the activation event', () => {
+  const state: ExtensionDetailState = {
+    ...createDefaultState(),
+    activationTime: 20,
+    importTime: 5,
+    status: RuntimeStatusType.Activated,
+    wasActivatedByEvent: 'onCommand:runtimeStatus.activate',
+  }
+
+  const result = getRuntimeStatusVirtualDom(state)
+
+  expect(result[3]).toEqual({
+    childCount: 8,
+    className: 'RuntimeStatusDefinitionList',
+    type: VirtualDomElements.Dl,
+  })
+  expect(result).toContainEqual({
+    childCount: 0,
+    text: 'onCommand:runtimeStatus.activate',
     type: VirtualDomElements.Text,
   })
 })
@@ -208,7 +231,7 @@ test('getRuntimeStatusVirtualDom should format activation time correctly', () =>
   expect(result).toHaveLength(16)
   expect(result[15]).toEqual({
     childCount: 0,
-    text: '0.00ms',
+    text: '123.46ms',
     type: VirtualDomElements.Text,
   })
 })

--- a/packages/extension-detail-view-worker/test/GetRuntimeActivationEventVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetRuntimeActivationEventVirtualDom.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@jest/globals'
+import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import { getRuntimeActivationEventVirtualDom } from '../src/parts/GetRuntimeActivationEventVirtualDom/GetRuntimeActivationEventVirtualDom.ts'
+
+test('returns no nodes without an activation event', () => {
+  expect(getRuntimeActivationEventVirtualDom('')).toEqual([])
+})
+
+test('renders the activation event', () => {
+  expect(getRuntimeActivationEventVirtualDom('onCommand:runtimeStatus.activate')).toEqual([
+    {
+      childCount: 1,
+      className: 'RuntimeStatusDefinitionListKey',
+      type: VirtualDomElements.Dt,
+    },
+    {
+      childCount: 0,
+      text: 'Activation Event: ',
+      type: VirtualDomElements.Text,
+    },
+    {
+      childCount: 1,
+      className: 'RuntimeStatusDefinitionListValue',
+      type: VirtualDomElements.Dd,
+    },
+    {
+      childCount: 1,
+      type: VirtualDomElements.Code,
+    },
+    {
+      childCount: 0,
+      text: 'onCommand:runtimeStatus.activate',
+      type: VirtualDomElements.Text,
+    },
+  ])
+})

--- a/packages/extension-detail-view-worker/test/GetRuntimeStatus.test.ts
+++ b/packages/extension-detail-view-worker/test/GetRuntimeStatus.test.ts
@@ -1,10 +1,10 @@
-import { test, expect } from '@jest/globals'
+import { expect, test } from '@jest/globals'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import type { RuntimeStatus } from '../src/parts/RuntimeStatus/RuntimeStatus.ts'
-import * as ExtensionHostWorker from '../src/parts/ExtensionHostWorker/ExtensionHostWorker.ts'
 import { getRuntimeStatus } from '../src/parts/GetRuntimeStatus/GetRuntimeStatus.ts'
 import * as RuntimeStatusType from '../src/parts/RuntimeStatusType/RuntimeStatusType.ts'
 
-test('getRuntimeStatus should return runtime status from ExtensionHostWorker', async () => {
+test('getRuntimeStatus should return runtime status from ExtensionManagementWorker', async () => {
   const mockRuntimeStatus: RuntimeStatus = {
     activationEvent: 'onStartupFinished',
     activationTime: 1_234_567_890,
@@ -13,8 +13,8 @@ test('getRuntimeStatus should return runtime status from ExtensionHostWorker', a
     status: RuntimeStatusType.Activated,
   }
 
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       return mockRuntimeStatus
     },
   })
@@ -26,7 +26,7 @@ test('getRuntimeStatus should return runtime status from ExtensionHostWorker', a
   expect(result.activationEvent).toBe('onStartupFinished')
   expect(result.status).toBe(RuntimeStatusType.Activated)
   expect(result.activationTime).toBe(1_234_567_890)
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'test-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'test-extension']])
 })
 
 test('getRuntimeStatus should handle different extension IDs', async () => {
@@ -38,8 +38,8 @@ test('getRuntimeStatus should handle different extension IDs', async () => {
     status: RuntimeStatusType.Error,
   }
 
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       return mockRuntimeStatus
     },
   })
@@ -51,16 +51,16 @@ test('getRuntimeStatus should handle different extension IDs', async () => {
   expect(result.activationEvent).toBe('onCommand')
   expect(result.status).toBe(RuntimeStatusType.Error)
   expect(result.activationTime).toBe(9_876_543_210)
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'another-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'another-extension']])
 })
 
-test('getRuntimeStatus should propagate errors from ExtensionHostWorker', async () => {
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
-      throw new Error('Extension host error')
+test('getRuntimeStatus should propagate errors from ExtensionManagementWorker', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
+      throw new Error('Extension management error')
     },
   })
 
-  await expect(getRuntimeStatus('test-extension')).rejects.toThrow('Extension host error')
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'test-extension']])
+  await expect(getRuntimeStatus('test-extension')).rejects.toThrow('Extension management error')
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'test-extension']])
 })

--- a/packages/extension-detail-view-worker/test/HandleExtensionsStatusUpdate.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleExtensionsStatusUpdate.test.ts
@@ -1,8 +1,8 @@
-import { test, expect } from '@jest/globals'
+import { expect, test } from '@jest/globals'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../src/parts/ExtensionDetailState/ExtensionDetailState.ts'
 import type { RuntimeStatus } from '../src/parts/RuntimeStatus/RuntimeStatus.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
-import * as ExtensionHostWorker from '../src/parts/ExtensionHostWorker/ExtensionHostWorker.ts'
 import { handleExtensionsStatusUpdate } from '../src/parts/HandleExtensionsStatusUpdate/HandleExtensionsStatusUpdate.ts'
 import * as RuntimeStatusType from '../src/parts/RuntimeStatusType/RuntimeStatusType.ts'
 
@@ -15,8 +15,8 @@ test('handleExtensionsStatusUpdate should update state with runtime status detai
     status: RuntimeStatusType.Activated,
   }
 
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       return mockRuntimeStatus
     },
   })
@@ -36,7 +36,7 @@ test('handleExtensionsStatusUpdate should update state with runtime status detai
   expect(result.status).toBe(RuntimeStatusType.Activated)
   expect(result.wasActivatedByEvent).toBe('onStartupFinished')
   expect(result.extension).toBe(state.extension)
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'test-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'test-extension']])
 })
 
 test('handleExtensionsStatusUpdate should handle different activation events', async () => {
@@ -48,8 +48,8 @@ test('handleExtensionsStatusUpdate should handle different activation events', a
     status: RuntimeStatusType.Activating,
   }
 
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       return mockRuntimeStatus
     },
   })
@@ -68,7 +68,7 @@ test('handleExtensionsStatusUpdate should handle different activation events', a
   expect(result.importTime).toBe(5)
   expect(result.status).toBe(RuntimeStatusType.Activating)
   expect(result.wasActivatedByEvent).toBe('onCommand:test.command')
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'another-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'another-extension']])
 })
 
 test('handleExtensionsStatusUpdate should handle error status', async () => {
@@ -80,8 +80,8 @@ test('handleExtensionsStatusUpdate should handle error status', async () => {
     status: RuntimeStatusType.Error,
   }
 
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       return mockRuntimeStatus
     },
   })
@@ -100,7 +100,7 @@ test('handleExtensionsStatusUpdate should handle error status', async () => {
   expect(result.importTime).toBe(0)
   expect(result.status).toBe(RuntimeStatusType.Error)
   expect(result.wasActivatedByEvent).toBe('')
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'error-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'error-extension']])
 })
 
 test('handleExtensionsStatusUpdate should preserve other state properties', async () => {
@@ -112,8 +112,8 @@ test('handleExtensionsStatusUpdate should preserve other state properties', asyn
     status: RuntimeStatusType.Activated,
   }
 
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       return mockRuntimeStatus
     },
   })
@@ -137,12 +137,12 @@ test('handleExtensionsStatusUpdate should preserve other state properties', asyn
   expect(result.activationTime).toBe(100)
   expect(result.importTime).toBe(20)
   expect(result.status).toBe(RuntimeStatusType.Activated)
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'test-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'test-extension']])
 })
 
 test('handleExtensionsStatusUpdate should propagate errors from getRuntimeStatus', async () => {
-  using mockRpc = ExtensionHostWorker.registerMockRpc({
-    'ExtensionHost.getRuntimeStatus': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getRuntimeStatus': () => {
       throw new Error('Runtime status error')
     },
   })
@@ -156,5 +156,5 @@ test('handleExtensionsStatusUpdate should propagate errors from getRuntimeStatus
   }
 
   await expect(handleExtensionsStatusUpdate(state)).rejects.toThrow('Runtime status error')
-  expect(mockRpc.invocations).toEqual([['ExtensionHost.getRuntimeStatus', 'failing-extension']])
+  expect(mockRpc.invocations).toEqual([['Extensions.getRuntimeStatus', 'failing-extension']])
 })


### PR DESCRIPTION
Fix the runtime status tab to query the authoritative extension-management status store.

Display the recorded activation event and correctly associate import and activation durations, with regression coverage for a genuinely activated extension.