### PR TITLE
fix: account for runtime status worker memory

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 585_000
+export const threshold = 586_000
 
 export const instantiations = 16000
 


### PR DESCRIPTION
The runtime status activation event adds a small amount of worker code. Increase the explicit memory ceiling by 1 KB after macOS measured 585,064 bytes against the previous 585,000-byte ceiling.

Validated locally with `npm run measure` (584,984 bytes).