### PR TITLE
feature: increase unit test branch coverage

### DIFF
--- a/packages/extension-detail-view-worker/package.json
+++ b/packages/extension-detail-view-worker/package.json
@@ -39,7 +39,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 90,
+        "branches": 97,
         "functions": 90,
         "lines": 90
       }

--- a/packages/extension-detail-view-worker/test/ApplyRender.test.ts
+++ b/packages/extension-detail-view-worker/test/ApplyRender.test.ts
@@ -50,6 +50,15 @@ test('applyRender with empty diff result', () => {
   expect(commands).toHaveLength(0)
 })
 
+test('applyRender omits empty renderer commands', () => {
+  const oldState = CreateDefaultState.createDefaultState()
+  const newState = CreateDefaultState.createDefaultState()
+
+  const commands = ApplyRender.applyRender(oldState, newState, [DiffType.RenderScrollTop])
+
+  expect(commands).toEqual([])
+})
+
 test('applyRender throws error for unknown diff type', () => {
   const oldState = CreateDefaultState.createDefaultState()
   const newState = CreateDefaultState.createDefaultState()

--- a/packages/extension-detail-view-worker/test/CopyImageUrl.test.ts
+++ b/packages/extension-detail-view-worker/test/CopyImageUrl.test.ts
@@ -24,3 +24,13 @@ test('copyImageUrl calls writeText with absolute URL and returns state unchanged
   expect(mockRpc.invocations).toEqual([['ClipBoard.writeText', 'https://example.com/test/icon.png']])
   expect(result).toBe(state)
 })
+
+test('copyImageUrl does not write when the icon source is empty', async () => {
+  using mockRpc = ClipBoardWorker.registerMockRpc({})
+  const state = createDefaultState()
+
+  const result = await CopyImageUrl.copyImageUrl(state)
+
+  expect(mockRpc.invocations).toEqual([])
+  expect(result).toBe(state)
+})

--- a/packages/extension-detail-view-worker/test/FormatCreated.test.ts
+++ b/packages/extension-detail-view-worker/test/FormatCreated.test.ts
@@ -16,3 +16,16 @@ test('formatCreated returns relative time for future date', () => {
   const now = new Date('2024-01-15').getTime()
   expect(FormatCreated.formatCreated(created, now)).toBe('in 2 years')
 })
+
+test('formatCreated returns n/a for a non-finite timestamp', () => {
+  expect(FormatCreated.formatCreated(Number.NaN)).toBe('n/a')
+})
+
+test.each([
+  [45 * 24 * 60 * 60 * 1000, '1 month ago'],
+  [2 * 24 * 60 * 60 * 1000, '2 days ago'],
+  [2 * 60 * 60 * 1000, '2 hours ago'],
+  [2 * 60 * 1000, '2 minutes ago'],
+])('formatCreated selects the appropriate relative unit', (difference, expected) => {
+  expect(FormatCreated.formatCreated(0, difference)).toBe(expected)
+})

--- a/packages/extension-detail-view-worker/test/GetCategories.test.ts
+++ b/packages/extension-detail-view-worker/test/GetCategories.test.ts
@@ -12,3 +12,15 @@ test('getCategories returns themes category', () => {
     },
   ])
 })
+
+test('getCategories stringifies non-string categories', () => {
+  const categories = getCategories({
+    categories: [{ name: 'Themes' }],
+  })
+  expect(categories).toEqual([
+    {
+      id: '{"name":"themes"}',
+      label: '{"name":"Themes"}',
+    },
+  ])
+})

--- a/packages/extension-detail-view-worker/test/GetCurrentColorThemeId.test.ts
+++ b/packages/extension-detail-view-worker/test/GetCurrentColorThemeId.test.ts
@@ -36,3 +36,60 @@ test('getCurrentColorTheme returns empty string when preference is undefined', a
     ['Preferences.get', 'workbnech.colorTheme'],
   ])
 })
+
+test('getCurrentColorTheme returns the current theme from all preferences', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Preferences.get': () => undefined,
+    'Preferences.getAll': () => ({
+      'workbench.colorTheme': 'all-preferences-theme',
+    }),
+  })
+  const result = await getCurrentColorTheme()
+  expect(result).toBe('all-preferences-theme')
+  expect(mockRpc.invocations).toEqual([['Preferences.get', 'workbench.colorTheme'], ['Preferences.getAll']])
+})
+
+test('getCurrentColorTheme returns the legacy theme from all preferences', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Preferences.get': () => undefined,
+    'Preferences.getAll': () => ({
+      'workbnech.colorTheme': 'legacy-all-preferences-theme',
+    }),
+  })
+  const result = await getCurrentColorTheme()
+  expect(result).toBe('legacy-all-preferences-theme')
+  expect(mockRpc.invocations).toEqual([['Preferences.get', 'workbench.colorTheme'], ['Preferences.getAll']])
+})
+
+test('getCurrentColorTheme returns the legacy preference value', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Preferences.get': (key: string) => {
+      return key === 'workbnech.colorTheme' ? 'legacy-theme' : undefined
+    },
+    'Preferences.getAll': () => ({}),
+  })
+  const result = await getCurrentColorTheme()
+  expect(result).toBe('legacy-theme')
+  expect(mockRpc.invocations).toEqual([
+    ['Preferences.get', 'workbench.colorTheme'],
+    ['Preferences.getAll'],
+    ['Preferences.get', 'workbnech.colorTheme'],
+  ])
+})
+
+test.each([null, 42, { 'workbench.colorTheme': 42, 'workbnech.colorTheme': 42 }])(
+  'getCurrentColorTheme ignores invalid all-preferences value: %p',
+  async (preferences) => {
+    using mockRpc = RendererWorker.registerMockRpc({
+      'Preferences.get': () => undefined,
+      'Preferences.getAll': () => preferences,
+    })
+    const result = await getCurrentColorTheme()
+    expect(result).toBe('')
+    expect(mockRpc.invocations).toEqual([
+      ['Preferences.get', 'workbench.colorTheme'],
+      ['Preferences.getAll'],
+      ['Preferences.get', 'workbnech.colorTheme'],
+    ])
+  },
+)

--- a/packages/extension-detail-view-worker/test/GetExtensionDetailMetadataVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetExtensionDetailMetadataVirtualDom.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@jest/globals'
+import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import { getExtensionDetailMetadataVirtualDom } from '../src/parts/GetExtensionDetailMetadataVirtualDom/GetExtensionDetailMetadataVirtualDom.ts'
+
+test('renders only the download count when the rating is unavailable', () => {
+  expect(getExtensionDetailMetadataVirtualDom('1,000', 'n/a')).toEqual([
+    {
+      childCount: 1,
+      className: 'ExtensionDetailMetadata',
+      type: VirtualDomElements.Div,
+    },
+    {
+      ariaLabel: 'Downloads: 1,000',
+      childCount: 1,
+      className: 'ExtensionDetailStatistic ExtensionDetailDownloadCount',
+      title: 'Downloads: 1,000',
+      type: VirtualDomElements.Span,
+    },
+    {
+      childCount: 0,
+      text: '1,000',
+      type: VirtualDomElements.Text,
+    },
+  ])
+})

--- a/packages/extension-detail-view-worker/test/GetExtensionDetailVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetExtensionDetailVirtualDom.test.ts
@@ -298,3 +298,14 @@ test('getExtensionDetailVirtualDom - non-builtin extension shows no badge', () =
   // The badge should be empty for non-builtin extensions
   expect(result).toBeDefined()
 })
+
+test('getExtensionDetailVirtualDom uses the fallback width when width is zero', () => {
+  const extensionDetail = {
+    ...createDefaultState(),
+    width: 0,
+  }
+
+  const result = GetExtensionDetailVirtualDom.getExtensionDetailVirtualDom(extensionDetail, '')
+
+  expect(result).toBeDefined()
+})

--- a/packages/extension-detail-view-worker/test/GetExtensionInfoText.test.ts
+++ b/packages/extension-detail-view-worker/test/GetExtensionInfoText.test.ts
@@ -41,3 +41,11 @@ test('omits an unavailable marketplace link and falls back to the publisher id',
     ['Name: Test Extension', 'Id: test.extension', 'Description: ', 'Version: n/a', 'Publisher: test-publisher'].join('\n'),
   )
 })
+
+test('falls back when publisher information is unavailable', () => {
+  const state = {
+    ...createDefaultState(),
+    extension: {},
+  }
+  expect(getExtensionInfoText(state)).toContain('Publisher: n/a')
+})

--- a/packages/extension-detail-view-worker/test/GetFeatureDetailsCommands.test.ts
+++ b/packages/extension-detail-view-worker/test/GetFeatureDetailsCommands.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@jest/globals'
+import { getFeatureDetailsCommand } from '../src/parts/GetFeatureDetailsCommands/GetFeatureDetailsCommands.ts'
+
+test('returns no command rows when commands are missing', () => {
+  expect(getFeatureDetailsCommand({})).toEqual({
+    commands: [],
+  })
+})

--- a/packages/extension-detail-view-worker/test/GetFeatureDetailsSettings.test.ts
+++ b/packages/extension-detail-view-worker/test/GetFeatureDetailsSettings.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@jest/globals'
+import { getFeatureDetailsSettings } from '../src/parts/GetFeatureDetailsSettings/GetFeatureDetailsSettings.ts'
+
+test('returns no setting rows when settings are missing', () => {
+  expect(getFeatureDetailsSettings({})).toEqual({
+    settings: [],
+  })
+})

--- a/packages/extension-detail-view-worker/test/GetIcon.test.ts
+++ b/packages/extension-detail-view-worker/test/GetIcon.test.ts
@@ -81,3 +81,11 @@ test('getIcon prefers language basics over theme when both conditions match', ()
   const result = getIcon(extension, PlatformType.Web, assetDir)
   expect(result).toBe(`${assetDir}/icons/language-icon.svg`)
 })
+
+test('getIcon returns an empty string for an unknown platform', () => {
+  const extension = {
+    icon: 'icon.png',
+    path: '/path/to/extension',
+  }
+  expect(getIcon(extension, 999, assetDir)).toBe('')
+})

--- a/packages/extension-detail-view-worker/test/GetJsonValidationTableEntry.test.ts
+++ b/packages/extension-detail-view-worker/test/GetJsonValidationTableEntry.test.ts
@@ -73,3 +73,46 @@ test('returns invalid cells for array validation', () => {
   const row = GetJsonValidationTableEntry.getJsonValidationTableEntry(validation as any)
   expect(row).toEqual([{ type: TableCellType.Text }, { className: ClassNames.TableCellInvalid, type: TableCellType.Text }])
 })
+
+test('returns an invalid link cell when an invalid validation has a schema', () => {
+  const validation: JsonValidationInfo = {
+    errorMessage: 'Invalid package',
+    fileMatch: ['package.json'] as any,
+    isValid: false,
+    schemaUrl: 'https://example.com/schema.json',
+    stringValue: 'schema.json',
+  }
+  expect(GetJsonValidationTableEntry.getJsonValidationTableEntry(validation)).toEqual([
+    {
+      type: TableCellType.Code,
+      value: ['package.json'],
+    },
+    {
+      className: ClassNames.TableCellInvalid,
+      href: 'https://example.com/schema.json',
+      title: 'Invalid package',
+      type: TableCellType.Link,
+      value: 'schema.json',
+    },
+  ])
+})
+
+test('returns a text cell when a valid validation has no schema', () => {
+  const validation: JsonValidationInfo = {
+    errorMessage: '',
+    fileMatch: ['package.json'] as any,
+    isValid: true,
+    schemaUrl: '',
+    stringValue: '',
+  }
+  expect(GetJsonValidationTableEntry.getJsonValidationTableEntry(validation)).toEqual([
+    {
+      type: TableCellType.Code,
+      value: ['package.json'],
+    },
+    {
+      type: TableCellType.Text,
+      value: '',
+    },
+  ])
+})

--- a/packages/extension-detail-view-worker/test/GetMenuEntries2.test.ts
+++ b/packages/extension-detail-view-worker/test/GetMenuEntries2.test.ts
@@ -26,3 +26,72 @@ test('returns copy actions for the extension management menu', () => {
     },
   ])
 })
+
+test('returns image actions for the extension icon menu', () => {
+  const state = createDefaultState()
+  expect(
+    getMenuEntries2(state, {
+      menuId: MenuEntryId.ExtensionDetailIconContextMenu,
+    }),
+  ).toEqual([
+    {
+      args: [],
+      command: 'ExtensionDetail.copyImage',
+      flags: MenuItemFlags.None,
+      id: 'copyImage',
+      label: 'Copy Image',
+    },
+    {
+      args: [],
+      command: 'ExtensionDetail.copyImageUrl',
+      flags: MenuItemFlags.None,
+      id: 'copyImage',
+      label: 'Copy Image Url',
+    },
+  ])
+})
+
+test('returns link and copy actions for a readme link', () => {
+  const state = createDefaultState()
+  expect(
+    getMenuEntries2(state, {
+      href: 'https://example.com',
+      menuId: MenuEntryId.ExtensionDetailReadme,
+      nodeName: 'A',
+    }),
+  ).toEqual([
+    {
+      args: ['https://example.com'],
+      command: 'ExtensionDetail.copyReadmeLink',
+      flags: MenuItemFlags.None,
+      id: 'copyLink',
+      label: 'Copy Link',
+    },
+    {
+      args: [],
+      command: 'ExtensionDetail.executeCopy',
+      flags: MenuItemFlags.None,
+      id: 'copy',
+      label: 'Copy',
+    },
+  ])
+})
+
+test('returns only the copy action when a readme context menu has no link', () => {
+  const state = createDefaultState()
+  expect(
+    getMenuEntries2(state, {
+      href: '',
+      menuId: MenuEntryId.ExtensionDetailReadme,
+      nodeName: 'P',
+    }),
+  ).toEqual([
+    {
+      args: [],
+      command: 'ExtensionDetail.executeCopy',
+      flags: MenuItemFlags.None,
+      id: 'copy',
+      label: 'Copy',
+    },
+  ])
+})

--- a/packages/extension-detail-view-worker/test/GetMoreInfoEntryVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetMoreInfoEntryVirtualDom.test.ts
@@ -30,3 +30,17 @@ test('more info entry virtual dom', () => {
     text('MIT'),
   ])
 })
+
+test('odd more info entry virtual dom', () => {
+  const entry: MoreInfoEntry = {
+    key: 'License',
+    odd: true,
+    value: 'MIT',
+  }
+  const result = GetMoreInfoEntryVirtualDom.getMoreInfoEntryVirtualDom(entry)
+  expect(result[0]).toEqual({
+    childCount: 2,
+    className: `${ClassNames.MoreInfoEntry} ${ClassNames.MoreInfoEntryOdd}`,
+    type: VirtualDomElements.Div,
+  })
+})

--- a/packages/extension-detail-view-worker/test/GetRenderer.test.ts
+++ b/packages/extension-detail-view-worker/test/GetRenderer.test.ts
@@ -5,6 +5,7 @@ import * as RenderCss from '../src/parts/RenderCss/RenderCss.ts'
 import * as RenderDom from '../src/parts/RenderDom/RenderDom.ts'
 import * as RenderFocus from '../src/parts/RenderFocus/RenderFocus.ts'
 import { renderFocusContext } from '../src/parts/RenderFocusContext/RenderFocusContext.ts'
+import { renderIncremental } from '../src/parts/RenderIncremental/RenderIncremental.ts'
 import * as RenderScrollTop from '../src/parts/RenderScrollTop/RenderScrollTop.ts'
 
 test('getRenderer - RenderItems', () => {
@@ -30,6 +31,11 @@ test('getRenderer - RenderCss', () => {
 test('getRenderer - RenderFocusContext', () => {
   const renderer = GetRenderer.getRenderer(DiffType.RenderFocusContext)
   expect(renderer).toBe(renderFocusContext)
+})
+
+test('getRenderer - RenderIncremental', () => {
+  const renderer = GetRenderer.getRenderer(DiffType.RenderIncremental)
+  expect(renderer).toBe(renderIncremental)
 })
 
 test('getRenderer - unknown type throws', () => {

--- a/packages/extension-detail-view-worker/test/GetResourceVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetResourceVirtualDom.test.ts
@@ -23,3 +23,33 @@ test('resource virtual dom', () => {
     text('Test Resource'),
   ])
 })
+
+test('resource virtual dom with an icon', () => {
+  const resource: Resource = {
+    icon: 'Github',
+    label: 'Repository',
+    url: 'https://github.com/example/repository',
+  }
+  expect(GetResourceVirtualDom.getResourceVirtualDom(resource)).toEqual([
+    {
+      childCount: 2,
+      className: 'Resource',
+      href: 'https://github.com/example/repository',
+      onClick: 19,
+      rel: 'noopener noreferrer',
+      target: '_blank',
+      type: VirtualDomElements.A,
+    },
+    {
+      childCount: 1,
+      className: 'ResourceIcon',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 0,
+      className: 'MaskIcon MaskIconGithub',
+      type: VirtualDomElements.Div,
+    },
+    text('Repository'),
+  ])
+})

--- a/packages/extension-detail-view-worker/test/GetSyntaxLanguages.test.ts
+++ b/packages/extension-detail-view-worker/test/GetSyntaxLanguages.test.ts
@@ -29,6 +29,27 @@ test('returns normalized extension-contributed languages', async () => {
   expect(mockRpc.invocations).toEqual([['Extensions.getLanguages', 1, '/assets']])
 })
 
+test('returns a language without optional aliases or extensions', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.getLanguages': () => [
+      {
+        id: 'plaintext',
+        tokenize: '/extensions/plaintext/tokenize.js',
+      },
+    ],
+  })
+
+  await expect(getSyntaxLanguages(1, '/assets')).resolves.toEqual([
+    {
+      aliases: undefined,
+      extensions: undefined,
+      id: 'plaintext',
+      tokenize: '/extensions/plaintext/tokenize.js',
+    },
+  ])
+  expect(mockRpc.invocations).toEqual([['Extensions.getLanguages', 1, '/assets']])
+})
+
 test('returns empty languages for invalid response', async () => {
   using mockRpc = ExtensionManagementWorker.registerMockRpc({
     'Extensions.getLanguages': () => ({}),

--- a/packages/extension-detail-view-worker/test/GithubApiRequest.test.ts
+++ b/packages/extension-detail-view-worker/test/GithubApiRequest.test.ts
@@ -33,3 +33,22 @@ test('stateful mock commands preserve the view state', async () => {
   await expect(GithubApiRequest.request('https://api.github.com/test')).resolves.toBeInstanceOf(Response)
   expect(GithubApiRequest.handleResetGithubApiMock(state)).toBe(state)
 })
+
+test('uses explicit mock response values', async () => {
+  GithubApiRequest.mockGithubApi({
+    body: { message: 'custom body' },
+    status: 500,
+    statusText: 'Custom Server Error',
+    type: 'response',
+  })
+  const response = await GithubApiRequest.request('https://api.github.com/test')
+  expect(response.status).toBe(500)
+  expect(response.statusText).toBe('Custom Server Error')
+  await expect(response.json()).resolves.toEqual({ message: 'custom body' })
+})
+
+test('defaults an omitted mock body to an empty array', async () => {
+  GithubApiRequest.mockGithubApi({ type: 'success' })
+  const response = await GithubApiRequest.request('https://api.github.com/test')
+  await expect(response.json()).resolves.toEqual([])
+})

--- a/packages/extension-detail-view-worker/test/HandleClickScrollToTop.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleClickScrollToTop.test.ts
@@ -42,3 +42,11 @@ test('handleClickScrollToTop - returns unchanged state when changelog is already
   }
   expect(handleClickScrollToTop(state)).toBe(state)
 })
+
+test('handleClickScrollToTop - returns unchanged state when readme is already at top', () => {
+  const state = {
+    ...createDefaultState(),
+    readmeScrollTop: 0,
+  }
+  expect(handleClickScrollToTop(state)).toBe(state)
+})

--- a/packages/extension-detail-view-worker/test/HandleClickSetColorTheme.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleClickSetColorTheme.test.ts
@@ -101,13 +101,13 @@ test('handleClickSetColorTheme - extension with empty color themes', async () =>
   expect(mockRpc.invocations).toEqual([])
 })
 
-test.skip('handleClickSetColorTheme - extension with color theme error', async () => {
+test('handleClickSetColorTheme - reports a color theme error', async () => {
   const errorMessage = 'Failed to set color theme'
   using mockRpc = RendererWorker.registerMockRpc({
     'ColorTheme.setColorTheme': () => {
       return errorMessage
     },
-    confirm: () => {
+    'ConfirmPrompt.prompt': () => {
       return ''
     },
   })
@@ -120,9 +120,10 @@ test.skip('handleClickSetColorTheme - extension with color theme error', async (
   }
 
   const result = await HandleClickSetColorTheme.handleClickSetColorTheme(state)
-  expect(result).toBe(state)
+  expect(result).not.toBe(state)
+  expect(result.currentColorThemeId).toBe('theme1')
   expect(mockRpc.invocations).toEqual([
     ['ColorTheme.setColorTheme', 'theme1'],
-    ['confirm', errorMessage],
+    ['ConfirmPrompt.prompt', errorMessage],
   ])
 })

--- a/packages/extension-detail-view-worker/test/HandleColorThemeChanged.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleColorThemeChanged.test.ts
@@ -44,3 +44,12 @@ test('returns the same state when the color theme did not change', () => {
 
   expect(result).toBe(state)
 })
+
+test('updates the active theme when the extension has no color theme metadata', () => {
+  const state = CreateDefaultState.createDefaultState()
+
+  const result = handleColorThemeChanged(state, 'slime')
+
+  expect(result).not.toBe(state)
+  expect(result.currentColorThemeId).toBe('slime')
+})

--- a/packages/extension-detail-view-worker/test/HandleResourceLinkClick.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleResourceLinkClick.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@jest/globals'
+import { PlatformType } from '@lvce-editor/constants'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleResourceLinkClick } from '../src/parts/HandleResourceLinkClick/HandleResourceLinkClick.ts'
+
+test.each(['', 'README.md'])('ignores an invalid resource link: %p', async (href) => {
+  using mockRpc = RendererWorker.registerMockRpc({})
+  const state = createDefaultState()
+
+  const result = await handleResourceLinkClick(state, href)
+
+  expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([])
+})
+
+test.each(['http://example.com', 'https://example.com'])('opens an external resource link: %p', async (href) => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Open.openUrl': () => {
+      /**/
+    },
+  })
+  const state = {
+    ...createDefaultState(),
+    platform: PlatformType.Web,
+  }
+
+  const result = await handleResourceLinkClick(state, href)
+
+  expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([['Open.openUrl', href]])
+})

--- a/packages/extension-detail-view-worker/test/OpenExternal.test.ts
+++ b/packages/extension-detail-view-worker/test/OpenExternal.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@jest/globals'
+import { PlatformType } from '@lvce-editor/constants'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as OpenExternal from '../src/parts/OpenExternal/OpenExternal.ts'
 
@@ -13,4 +14,17 @@ test('openUrl calls RendererWorker.openUrl with the correct uri', async () => {
   await OpenExternal.openExternal(testUri, 0)
 
   expect(mockRpc.invocations).toEqual([['Open.openUrl', testUri]])
+})
+
+test('openExternal calls RendererWorker.openExternal on Electron', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Open.openExternal': () => {
+      /**/
+    },
+  })
+
+  const testUri = 'https://example.com'
+  await OpenExternal.openExternal(testUri, PlatformType.Electron)
+
+  expect(mockRpc.invocations).toEqual([['Open.openExternal', testUri]])
 })

--- a/packages/extension-detail-view-worker/test/RenderDom.test.ts
+++ b/packages/extension-detail-view-worker/test/RenderDom.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@jest/globals'
+import { ViewletCommand } from '@lvce-editor/constants'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { renderDom } from '../src/parts/RenderDom/RenderDom.ts'
+
+test('renders an empty initial DOM', () => {
+  const oldState = createDefaultState()
+  const newState = {
+    ...createDefaultState(),
+    initial: true,
+    uid: 42,
+  }
+
+  expect(renderDom(oldState, newState)).toEqual([ViewletCommand.SetDom2, 42, []])
+})


### PR DESCRIPTION
Adds focused extension detail view unit tests for fallback, error, menu, resource-link, rendering, and formatting branches. Raises the enforced Jest branch coverage threshold to 97%.