### PR TITLE
feature: configure markdown cache application name

### DIFF
--- a/packages/extension-detail-view-worker/src/parts/GetCache/GetCache.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetCache/GetCache.ts
@@ -1,5 +1,3 @@
-// TODO pass application name from renderer worker to not hardcode it
-
 export interface ICache {
   readonly match: (request: RequestInfo | URL, options?: CacheQueryOptions) => Promise<Response | undefined>
   readonly put: (request: RequestInfo | URL, response: Response) => Promise<void>

--- a/packages/extension-detail-view-worker/src/parts/Initialize/Initialize.ts
+++ b/packages/extension-detail-view-worker/src/parts/Initialize/Initialize.ts
@@ -3,8 +3,10 @@ import { initializeExtensionHostWorker } from '../InitializeExtensionHostWorker/
 import { initializeExtensionManagementWorker } from '../InitializeExtensionManagementWorker/InitializeExtensionManagementWorker.ts'
 import { initializeFileSystemWorker } from '../InitializeFileSystemWorker/InitializeFileSystemWorker.ts'
 import { initializeMarkdownWorker } from '../InitializeMarkdownWorker/InitializeMarkdownWorker.ts'
+import { setApplicationName } from '../MarkDownCache/MarkDownCache.ts'
 
-export const initialize = async (): Promise<void> => {
+export const initialize = async (applicationName: string): Promise<void> => {
+  setApplicationName(applicationName)
   // TODO load markdown worker only when needed
   await Promise.all([
     initializeMarkdownWorker(),

--- a/packages/extension-detail-view-worker/src/parts/MarkDownCache/MarkDownCache.ts
+++ b/packages/extension-detail-view-worker/src/parts/MarkDownCache/MarkDownCache.ts
@@ -1,23 +1,28 @@
-import { getCache } from '../GetCache/GetCache.ts'
+import { getCache, type ICache } from '../GetCache/GetCache.ts'
 
-// TODO pass application name from renderer worker to not hardcode it
-const cacheName = 'lvce-editor/markdown-cache'
+type GetCache = (cacheName: string, bucketName: string) => Promise<ICache>
 
-export const has = async (key: string, bucketName: string): Promise<boolean> => {
-  const cache = await getCache(cacheName, bucketName)
+let cacheName = ''
+
+export const setApplicationName = (applicationName: string): void => {
+  cacheName = `${applicationName}/markdown-cache`
+}
+
+export const has = async (key: string, bucketName: string, getCacheFunction: GetCache = getCache): Promise<boolean> => {
+  const cache = await getCacheFunction(cacheName, bucketName)
   const response = await cache.match(key)
   return Boolean(response)
 }
 
-export const get = async (key: string, bucketName: string): Promise<string> => {
-  const cache = await getCache(cacheName, bucketName)
+export const get = async (key: string, bucketName: string, getCacheFunction: GetCache = getCache): Promise<string> => {
+  const cache = await getCacheFunction(cacheName, bucketName)
   const response = await cache.match(key)
   const text = await response?.text()
   return text || ''
 }
 
-export const set = async (key: string, bucketName: string, value: string): Promise<void> => {
-  const cache = await getCache(cacheName, bucketName)
+export const set = async (key: string, bucketName: string, value: string, getCacheFunction: GetCache = getCache): Promise<void> => {
+  const cache = await getCacheFunction(cacheName, bucketName)
   await cache.put(
     key,
     new Response(value, {

--- a/packages/extension-detail-view-worker/test/Initialize.test.ts
+++ b/packages/extension-detail-view-worker/test/Initialize.test.ts
@@ -9,7 +9,7 @@ test.skip('should initialize both workers successfully', async () => {
     'SendMessagePortToExtensionHostWorker.sendMessagePortToFileSystemWorker': () => {},
     'SendMessagePortToExtensionHostWorker.sendMessagePortToMarkdownWorker': () => {},
   })
-  await initialize()
+  await initialize('test-app')
   expect(mockRpc.invocations.length).toBeGreaterThanOrEqual(3)
   expect(mockRpc.invocations).toContainEqual([
     'SendMessagePortToExtensionHostWorker.sendMessagePortToMarkdownWorker',
@@ -62,7 +62,7 @@ test.skip('should handle initialization errors', async () => {
     },
   })
 
-  await expect(initialize()).rejects.toThrow('Failed to create markdown worker rpc')
+  await expect(initialize('test-app')).rejects.toThrow('Failed to create markdown worker rpc')
   expect(mockRpc.invocations.length).toBeGreaterThanOrEqual(1)
   expect(mockRpc.invocations).toContainEqual([
     'SendMessagePortToExtensionHostWorker.sendMessagePortToMarkdownWorker',

--- a/packages/extension-detail-view-worker/test/MarkDownCache.test.ts
+++ b/packages/extension-detail-view-worker/test/MarkDownCache.test.ts
@@ -1,15 +1,37 @@
 import { expect, test, jest } from '@jest/globals'
+import type * as MarkDownCacheModule from '../src/parts/MarkDownCache/MarkDownCache.ts'
 
 const resetModules = (): void => {
   jest.resetModules()
 }
+
+const loadMarkDownCache = async (): Promise<typeof MarkDownCacheModule> => {
+  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  MarkDownCache.setApplicationName('lvce-editor')
+  return MarkDownCache
+}
+
+test('uses the application name for the markdown cache', async () => {
+  resetModules()
+  const cache = {
+    match: jest.fn<(request: RequestInfo | URL) => Promise<Response | undefined>>().mockResolvedValue(undefined),
+    put: jest.fn<(request: RequestInfo | URL, response: Response) => Promise<void>>().mockResolvedValue(undefined),
+  }
+  const getCache = jest.fn<(cacheName: string, bucketName: string) => Promise<typeof cache>>().mockResolvedValue(cache)
+  const MarkDownCache = await loadMarkDownCache()
+  MarkDownCache.setApplicationName('test-app')
+
+  await MarkDownCache.has('test-key', 'markdown-cache', getCache)
+
+  expect(getCache).toHaveBeenCalledWith('test-app/markdown-cache', 'markdown-cache')
+})
 
 test.skip('has - returns false when storageBuckets is not supported', async () => {
   resetModules()
   const originalNavigator = globalThis.navigator
   // @ts-ignore
   globalThis.navigator = {}
-  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  const MarkDownCache = await loadMarkDownCache()
 
   const result = await MarkDownCache.has('test-key', 'markdown-cache')
 
@@ -41,7 +63,7 @@ test.skip('has - returns true when key exists in cache', async () => {
   globalThis.navigator = {
     storageBuckets: mockStorageBuckets,
   } as typeof globalThis.navigator
-  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  const MarkDownCache = await loadMarkDownCache()
 
   const result = await MarkDownCache.has('test-key', 'markdown-cache')
 
@@ -73,7 +95,7 @@ test.skip('has - returns false when key does not exist in cache', async () => {
   globalThis.navigator = {
     storageBuckets: mockStorageBuckets,
   } as typeof globalThis.navigator
-  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  const MarkDownCache = await loadMarkDownCache()
 
   const result = await MarkDownCache.has('non-existent-key', 'markdown-cache')
 
@@ -87,7 +109,7 @@ test.skip('get - returns empty string when storageBuckets is not supported', asy
   const originalNavigator = globalThis.navigator
   // @ts-ignore
   globalThis.navigator = {}
-  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  const MarkDownCache = await loadMarkDownCache()
 
   const result = await MarkDownCache.get('test-key', 'markdown-cache')
 
@@ -120,7 +142,7 @@ test.skip('get - returns cached value when key exists', async () => {
   globalThis.navigator = {
     storageBuckets: mockStorageBuckets,
   } as typeof globalThis.navigator
-  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  const MarkDownCache = await loadMarkDownCache()
 
   const result = await MarkDownCache.get('test-key', 'markdown-cache')
 
@@ -151,7 +173,7 @@ test.skip('get - returns empty string when key does not exist', async () => {
   globalThis.navigator = {
     storageBuckets: mockStorageBuckets,
   } as typeof globalThis.navigator
-  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  const MarkDownCache = await loadMarkDownCache()
 
   const result = await MarkDownCache.get('non-existent-key', 'markdown-cache')
 
@@ -165,7 +187,7 @@ test.skip('set - does nothing when storageBuckets is not supported', async () =>
   const originalNavigator = globalThis.navigator
   // @ts-ignore
   globalThis.navigator = {}
-  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  const MarkDownCache = await loadMarkDownCache()
 
   await MarkDownCache.set('test-key', 'markdown-cache', '<p>Hello</p>')
 
@@ -193,7 +215,7 @@ test.skip('set - stores value in cache with correct headers', async () => {
   globalThis.navigator = {
     storageBuckets: mockStorageBuckets,
   } as typeof globalThis.navigator
-  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  const MarkDownCache = await loadMarkDownCache()
 
   const key = 'test-key'
   const value = '<p>Hello World</p>'
@@ -231,7 +253,7 @@ test.skip('set - stores value with correct Content-Length for empty string', asy
   globalThis.navigator = {
     storageBuckets: mockStorageBuckets,
   } as typeof globalThis.navigator
-  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  const MarkDownCache = await loadMarkDownCache()
 
   const key = 'empty-key'
   const value = ''
@@ -268,7 +290,7 @@ test.skip('set - stores value with correct Content-Length for long string', asyn
   globalThis.navigator = {
     storageBuckets: mockStorageBuckets,
   } as typeof globalThis.navigator
-  const MarkDownCache = await import('../src/parts/MarkDownCache/MarkDownCache.ts')
+  const MarkDownCache = await loadMarkDownCache()
 
   const key = 'long-key'
   const value = 'x'.repeat(1000)


### PR DESCRIPTION
Pass the configured application name into the extension detail worker and use it to namespace the markdown cache.