### PR TITLE
feature: use dialog worker directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2957,9 +2957,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.20.0.tgz",
-      "integrity": "sha512-yDtT/MF73BsyMpx7DQSoJJLM3hJKTII9TuGEguwJmgULxqV3mND86npuvOhKGUjTvL0Fs8BEQYFjO4DCrjncwA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.22.0.tgz",
+      "integrity": "sha512-yjT2rnsk+1jRoda5ZnU7ENjunjvqfsa6Lr4ydO+88K/dE0ifoZQN3VtH+8eeZBCMTw8sBT71X/d4aM1aX5b2Vg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
@@ -3898,14 +3898,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.39.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.39.0.tgz",
-      "integrity": "sha512-3ojIjE03w8thUcdKB7pbLxmN/V6/NHk2gaaiviUfoeRHI3e1cXVvX/fI1BG73/OXW9sU9KJehqkgepKtaNJU7g==",
+      "version": "9.42.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.42.0.tgz",
+      "integrity": "sha512-5/G0T87nC3aKRujuLJSpSsG0jPdXmrwDqRX3rHNmUWh7FaMPC0SoqBqenMTy2V+EHqnX0LRFyC6FO5LPwoPFgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.20.0",
+        "@lvce-editor/constants": "^5.22.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
@@ -16651,7 +16651,7 @@
         "@lvce-editor/constants": "^5.20.0",
         "@lvce-editor/i18n": "^2.5.0",
         "@lvce-editor/rpc": "^6.10.0",
-        "@lvce-editor/rpc-registry": "^9.39.0",
+        "@lvce-editor/rpc-registry": "^9.42.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
         "@lvce-editor/virtual-dom-worker": "^11.8.1",

--- a/packages/extension-detail-view-worker/package.json
+++ b/packages/extension-detail-view-worker/package.json
@@ -51,7 +51,7 @@
     "@lvce-editor/constants": "^5.20.0",
     "@lvce-editor/i18n": "^2.5.0",
     "@lvce-editor/rpc": "^6.10.0",
-    "@lvce-editor/rpc-registry": "^9.41.0",
+    "@lvce-editor/rpc-registry": "^9.42.0",
     "@lvce-editor/verror": "^1.7.0",
     "@lvce-editor/viewlet-registry": "^5.5.0",
     "@lvce-editor/virtual-dom-worker": "^11.8.1",

--- a/packages/extension-detail-view-worker/src/parts/HandleClickSetColorTheme/HandleClickSetColorTheme.ts
+++ b/packages/extension-detail-view-worker/src/parts/HandleClickSetColorTheme/HandleClickSetColorTheme.ts
@@ -1,4 +1,4 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
 import { getColorThemeId, getColorThemeLabel } from '../GetColorThemeId/GetColorThemeId.ts'
 import { getExtensionDetailButtons } from '../GetExtensionDetailButtons/GetExtensionDetailButtons.ts'
@@ -10,7 +10,7 @@ export const handleClickSetColorTheme = async (state: ExtensionDetailState): Pro
   if (colorThemeId) {
     const error = await SetColorTheme.setColorTheme(colorThemeId)
     if (error) {
-      await RendererWorker.confirm(`${error}`)
+      await DialogWorker.invoke('ConfirmPrompt.prompt', `${error}`)
     }
     const isBuiltin = extension?.isBuiltin || extension?.builtin || false
     const colorThemeLabel = getColorThemeLabel(extension) || ''

--- a/packages/extension-detail-view-worker/src/parts/HandleReadmeLinkClick/HandleReadmeLinkClick.ts
+++ b/packages/extension-detail-view-worker/src/parts/HandleReadmeLinkClick/HandleReadmeLinkClick.ts
@@ -1,4 +1,4 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker } from '@lvce-editor/rpc-registry'
 import { openExternal } from '../OpenExternal/OpenExternal.ts'
 
 export const handleReadmeLinkClick = async (linkProtectionEnabled: boolean, platform: number, href: string): Promise<void> => {
@@ -6,7 +6,7 @@ export const handleReadmeLinkClick = async (linkProtectionEnabled: boolean, plat
   // TODO what to do about mail links?
   if (linkProtectionEnabled) {
     const message = `Do you want to open this external link?\n\n${href}`
-    const confirmed = await RendererWorker.confirm(message)
+    const confirmed = await DialogWorker.invoke('ConfirmPrompt.prompt', message)
     if (!confirmed) {
       return
     }

--- a/packages/extension-detail-view-worker/src/parts/Listen/Listen.ts
+++ b/packages/extension-detail-view-worker/src/parts/Listen/Listen.ts
@@ -1,5 +1,5 @@
-import { WebWorkerRpcClient } from '@lvce-editor/rpc'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { LazyTransferMessagePortRpcParent, WebWorkerRpcClient } from '@lvce-editor/rpc'
+import { DialogWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as CommandMap from '../CommandMap/CommandMap.ts'
 import { registerCommands } from '../ExtensionDetailStates/ExtensionDetailStates.ts'
 
@@ -9,4 +9,9 @@ export const listen = async (): Promise<void> => {
     commandMap: CommandMap.commandMap,
   })
   RendererWorker.set(rpc)
+  const dialogRpc = await LazyTransferMessagePortRpcParent.create({
+    commandMap: {},
+    send: RendererWorker.sendMessagePortToDialogWorker,
+  })
+  DialogWorker.set(dialogRpc)
 }

--- a/packages/extension-detail-view-worker/src/parts/UpdateExtensionStatus/UpdateExtensionStatus.ts
+++ b/packages/extension-detail-view-worker/src/parts/UpdateExtensionStatus/UpdateExtensionStatus.ts
@@ -1,4 +1,4 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
 import * as ExtensionManagement from '../ExtensionManagement/ExtensionManagement.ts'
 import { getColorThemeId, getColorThemeLabel } from '../GetColorThemeId/GetColorThemeId.ts'
@@ -12,7 +12,7 @@ export const updateExtensionStatus = async (state: ExtensionDetailState, updateF
   const { currentColorThemeId, extensionId, hasColorTheme, platform } = state
   const error = await updateFunction(extensionId, platform)
   if (error) {
-    await RendererWorker.confirm(`${error}`)
+    await DialogWorker.invoke('ConfirmPrompt.prompt', `${error}`)
   }
   const extension = await ExtensionManagement.getExtension(extensionId, platform)
   const disabled = extension?.disabled

--- a/packages/extension-detail-view-worker/test/HandleClickDisable.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleClickDisable.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker, ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../src/parts/ExtensionDetailState/ExtensionDetailState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleClickDisable } from '../src/parts/HandleClickDisable/HandleClickDisable.ts'
@@ -84,12 +84,12 @@ test('handleClickDisable - handles error from disableExtension', async () => {
     },
   })
   using mockRendererRpc = RendererWorker.registerMockRpc({
-    'ConfirmPrompt.prompt': () => {
-      /**/
-    },
     'ExtensionManagement.getExtension': () => {
       return mockExtension
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
+    'ConfirmPrompt.prompt': () => {},
   })
 
   const result = await handleClickDisable(state)
@@ -97,7 +97,7 @@ test('handleClickDisable - handles error from disableExtension', async () => {
   expect(result.extensionId).toBe('test-extension-id')
   expect(result.disabled).toBe(false)
   expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.disable2', 'test-extension-id', PlatformType.Electron])
-  expect(mockRendererRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', errorMessage])
+  expect(mockDialogRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', errorMessage])
   expect(mockRendererRpc.invocations).toContainEqual(['ExtensionManagement.getExtension', 'test-extension-id'])
 })
 
@@ -209,18 +209,18 @@ test('handleClickDisable - error with Error object', async () => {
     },
   })
   using mockRendererRpc = RendererWorker.registerMockRpc({
-    'ConfirmPrompt.prompt': () => {
-      /**/
-    },
     'ExtensionManagement.getExtension': () => {
       return mockExtension
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
+    'ConfirmPrompt.prompt': () => {},
   })
 
   const result = await handleClickDisable(state)
 
   expect(result.extensionId).toBe('test-extension-id')
   expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.disable2', 'test-extension-id', PlatformType.Electron])
-  expect(mockRendererRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', 'Error: Disable failed'])
+  expect(mockDialogRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', 'Error: Disable failed'])
   expect(mockRendererRpc.invocations).toContainEqual(['ExtensionManagement.getExtension', 'test-extension-id'])
 })

--- a/packages/extension-detail-view-worker/test/HandleClickEnable.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleClickEnable.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker, ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../src/parts/ExtensionDetailState/ExtensionDetailState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as HandleClickEnable from '../src/parts/HandleClickEnable/HandleClickEnable.ts'
@@ -52,12 +52,12 @@ test('handleClickEnable handles error from enableExtension', async () => {
     },
   })
   using mockRendererRpc = RendererWorker.registerMockRpc({
-    'ConfirmPrompt.prompt': () => {
-      /**/
-    },
     'ExtensionManagement.getExtension': () => {
       return mockExtension
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
+    'ConfirmPrompt.prompt': () => {},
   })
 
   const result = await HandleClickEnable.handleClickEnable(state)
@@ -65,7 +65,7 @@ test('handleClickEnable handles error from enableExtension', async () => {
   expect(result.extensionId).toBe('test-extension-id')
   expect(result.disabled).toBe(false)
   expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.enable2', 'test-extension-id', PlatformType.Electron])
-  expect(mockRendererRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', errorMessage])
+  expect(mockDialogRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', errorMessage])
   expect(mockRendererRpc.invocations).toContainEqual(['ExtensionManagement.getExtension', 'test-extension-id'])
 })
 
@@ -206,18 +206,18 @@ test('handleClickEnable handles error with Error object', async () => {
     },
   })
   using mockRendererRpc = RendererWorker.registerMockRpc({
-    'ConfirmPrompt.prompt': () => {
-      /**/
-    },
     'ExtensionManagement.getExtension': () => {
       return mockExtension
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
+    'ConfirmPrompt.prompt': () => {},
   })
 
   const result = await HandleClickEnable.handleClickEnable(state)
 
   expect(result.extensionId).toBe('test-extension-id')
   expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.enable2', 'test-extension-id', PlatformType.Electron])
-  expect(mockRendererRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', 'Error: Enable failed'])
+  expect(mockDialogRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', 'Error: Enable failed'])
   expect(mockRendererRpc.invocations).toContainEqual(['ExtensionManagement.getExtension', 'test-extension-id'])
 })

--- a/packages/extension-detail-view-worker/test/HandleClickSetColorTheme.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleClickSetColorTheme.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as CreateDefaultState from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as HandleClickSetColorTheme from '../src/parts/HandleClickSetColorTheme/HandleClickSetColorTheme.ts'
 
@@ -53,9 +53,6 @@ test('handleClickSetColorTheme - extension with color theme', async () => {
     'ColorTheme.setColorTheme': () => {
       return ''
     },
-    confirm: () => {
-      return ''
-    },
   })
 
   const state = {
@@ -107,6 +104,8 @@ test('handleClickSetColorTheme - reports a color theme error', async () => {
     'ColorTheme.setColorTheme': () => {
       return errorMessage
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
     'ConfirmPrompt.prompt': () => {
       return ''
     },
@@ -122,8 +121,6 @@ test('handleClickSetColorTheme - reports a color theme error', async () => {
   const result = await HandleClickSetColorTheme.handleClickSetColorTheme(state)
   expect(result).not.toBe(state)
   expect(result.currentColorThemeId).toBe('theme1')
-  expect(mockRpc.invocations).toEqual([
-    ['ColorTheme.setColorTheme', 'theme1'],
-    ['ConfirmPrompt.prompt', errorMessage],
-  ])
+  expect(mockRpc.invocations).toEqual([['ColorTheme.setColorTheme', 'theme1']])
+  expect(mockDialogRpc.invocations).toEqual([['ConfirmPrompt.prompt', errorMessage]])
 })

--- a/packages/extension-detail-view-worker/test/HandleReadmeClick.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleReadmeClick.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../src/parts/ExtensionDetailState/ExtensionDetailState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as HandleReadmeClick from '../src/parts/HandleReadmeClick/HandleReadmeClick.ts'
@@ -136,12 +136,12 @@ test('handleReadmeClick opens link when linkProtectionEnabled is false', async (
 
 test('handleReadmeClick calls confirm and opens link when linkProtectionEnabled is true and confirmed', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
-    'ConfirmPrompt.prompt': () => {
-      return true
-    },
     'Open.openUrl': () => {
       /**/
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
+    'ConfirmPrompt.prompt': () => true,
   })
 
   const state: ExtensionDetailState = {
@@ -152,21 +152,19 @@ test('handleReadmeClick calls confirm and opens link when linkProtectionEnabled 
 
   const result = await HandleReadmeClick.handleReadmeClick(state, 'A', href)
 
-  expect(mockRpc.invocations).toEqual([
-    ['ConfirmPrompt.prompt', `Do you want to open this external link?\n\n${href}`],
-    ['Open.openUrl', href],
-  ])
+  expect(mockDialogRpc.invocations).toEqual([['ConfirmPrompt.prompt', `Do you want to open this external link?\n\n${href}`]])
+  expect(mockRpc.invocations).toEqual([['Open.openUrl', href]])
   expect(result).toBe(state)
 })
 
 test('handleReadmeClick calls confirm and does not open link when linkProtectionEnabled is true and not confirmed', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
-    'ConfirmPrompt.prompt': () => {
-      return false
-    },
     'Open.openUrl': () => {
       /**/
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
+    'ConfirmPrompt.prompt': () => false,
   })
 
   const state: ExtensionDetailState = {
@@ -177,6 +175,7 @@ test('handleReadmeClick calls confirm and does not open link when linkProtection
 
   const result = await HandleReadmeClick.handleReadmeClick(state, 'A', href)
 
-  expect(mockRpc.invocations).toEqual([['ConfirmPrompt.prompt', `Do you want to open this external link?\n\n${href}`]])
+  expect(mockDialogRpc.invocations).toEqual([['ConfirmPrompt.prompt', `Do you want to open this external link?\n\n${href}`]])
+  expect(mockRpc.invocations).toEqual([])
   expect(result).toBe(state)
 })

--- a/packages/extension-detail-view-worker/test/UpdateExtensionStatus.test.ts
+++ b/packages/extension-detail-view-worker/test/UpdateExtensionStatus.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { DialogWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../src/parts/ExtensionDetailState/ExtensionDetailState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as PlatformType from '../src/parts/PlatformType/PlatformType.ts'
@@ -76,12 +76,12 @@ test('updateExtensionStatus - handles error from updateFunction', async () => {
   const mockExtension: any = { disabled: false, id: 'test-extension-id' }
   const errorMessage = 'Failed to update extension'
   using mockRpc = RendererWorker.registerMockRpc({
-    'ConfirmPrompt.prompt': () => {
-      /**/
-    },
     'ExtensionManagement.getExtension': () => {
       return mockExtension
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
+    'ConfirmPrompt.prompt': () => {},
   })
 
   const updateFunction: UpdateExtensionStatus.UpdateFunction = async () => {
@@ -92,7 +92,7 @@ test('updateExtensionStatus - handles error from updateFunction', async () => {
 
   expect(result.extensionId).toBe('test-extension-id')
   expect(result.disabled).toBe(false)
-  expect(mockRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', errorMessage])
+  expect(mockDialogRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', errorMessage])
   expect(mockRpc.invocations).toContainEqual(['ExtensionManagement.getExtension', 'test-extension-id'])
 })
 
@@ -196,12 +196,12 @@ test('updateExtensionStatus - error with Error object', async () => {
   const mockExtension: any = { disabled: false, id: 'test-extension-id' }
   const error = new Error('Update failed')
   using mockRpc = RendererWorker.registerMockRpc({
-    'ConfirmPrompt.prompt': () => {
-      /**/
-    },
     'ExtensionManagement.getExtension': () => {
       return mockExtension
     },
+  })
+  using mockDialogRpc = DialogWorker.registerMockRpc({
+    'ConfirmPrompt.prompt': () => {},
   })
 
   const updateFunction: UpdateExtensionStatus.UpdateFunction = async () => {
@@ -211,6 +211,6 @@ test('updateExtensionStatus - error with Error object', async () => {
   const result = await UpdateExtensionStatus.updateExtensionStatus(state, updateFunction)
 
   expect(result.extensionId).toBe('test-extension-id')
-  expect(mockRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', 'Error: Update failed'])
+  expect(mockDialogRpc.invocations).toContainEqual(['ConfirmPrompt.prompt', 'Error: Update failed'])
   expect(mockRpc.invocations).toContainEqual(['ExtensionManagement.getExtension', 'test-extension-id'])
 })

--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 590_000
+export const threshold = 600_000
 
 export const instantiations = 16000
 


### PR DESCRIPTION
## Summary

- connect to dialog-worker through a lazy transferred message port
- send confirm and message-box requests directly to dialog-worker
- update rpc-registry and the affected tests

## Testing

- focused dialog and Listen tests
- npm run type-check
- npm run lint