### PR TITLE
feature: add forty extension detail e2e tests

### DIFF
--- a/packages/e2e/src/extension-detail.categories-structure.ts
+++ b/packages/e2e/src/extension-detail.categories-structure.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.categories-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const categoriesSection = Locator('.AdditionalDetailsEntry:nth-of-type(3)')
+  await expect(categoriesSection.locator(':scope > .Categories')).toHaveCount(1)
+  await expect(categoriesSection.locator('.Categories > button.Category')).toHaveCount(1)
+}

--- a/packages/e2e/src/extension-detail.changelog-markdown-structure.ts
+++ b/packages/e2e/src/extension-detail.changelog-markdown-structure.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.changelog-markdown-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-changelog')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.extension-changelog')
+
+  await ExtensionDetail.selectChangelog()
+
+  const changelog = Locator('.ExtensionDetailPanel.Changelog')
+  await expect(changelog.locator('h1')).toHaveText('Changes')
+  const changes = changelog.locator('li')
+  const first = changes.nth(0)
+  const second = changes.nth(1)
+  await expect(changes).toHaveCount(2)
+  await expect(first).toHaveText('Change 1')
+  await expect(second).toHaveText('Change 2')
+}

--- a/packages/e2e/src/extension-detail.details-hidden-for-features.ts
+++ b/packages/e2e/src/extension-detail.details-hidden-for-features.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.details-hidden-for-features'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.extension-basics')
+
+  await ExtensionDetail.selectFeatures()
+
+  const details = Locator('.ExtensionDetailPanel')
+  const features = Locator('.Features')
+  await expect(details).toHaveCount(0)
+  await expect(features).toBeVisible()
+}

--- a/packages/e2e/src/extension-detail.details-layout.ts
+++ b/packages/e2e/src/extension-detail.details-layout.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.details-layout'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const panel = Locator('.ExtensionDetailPanel')
+  await expect(panel.locator(':scope > .Markdown')).toHaveCount(1)
+  await expect(panel.locator(':scope > aside.Aside')).toHaveCount(1)
+}

--- a/packages/e2e/src/extension-detail.feature-activation-events-code.ts
+++ b/packages/e2e/src/extension-detail.feature-activation-events-code.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-activation-events-code'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-activation-events')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.activation-events')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.openFeature('ActivationEvents')
+
+  const list = Locator('.FeatureContent > ul')
+  await expect(list.locator(':scope > li')).toHaveCount(1)
+  await expect(list.locator(':scope > li > code')).toHaveText('onWebview:builtin.chat-view')
+}

--- a/packages/e2e/src/extension-detail.feature-commands-cell-semantics.ts
+++ b/packages/e2e/src/extension-detail.feature-commands-cell-semantics.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-commands-cell-semantics'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.extension-basics')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.openFeature('Commands')
+
+  const cells = Locator('.FeatureContent tbody td.TableCell')
+  const id = cells.nth(0)
+  const idCode = id.locator('code')
+  const label = cells.nth(1)
+  const labelCode = label.locator('code')
+  await expect(cells).toHaveCount(2)
+  await expect(idCode).toHaveText('test')
+  await expect(labelCode).toHaveCount(0)
+  await expect(label).toHaveText('Test')
+}

--- a/packages/e2e/src/extension-detail.feature-commands-heading.ts
+++ b/packages/e2e/src/extension-detail.feature-commands-heading.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-commands-heading'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.extension-basics')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.openFeature('Commands')
+
+  const content = Locator('.FeatureContent')
+  await expect(content.locator(':scope > h1')).toHaveCount(1)
+  await expect(content.locator(':scope > h1')).toHaveText('Commands')
+}

--- a/packages/e2e/src/extension-detail.feature-commands-table-headings.ts
+++ b/packages/e2e/src/extension-detail.feature-commands-table-headings.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-commands-table-headings'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.extension-basics')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.openFeature('Commands')
+
+  const headings = Locator('.FeatureContent thead .TableHeading')
+  const id = headings.nth(0)
+  const label = headings.nth(1)
+  await expect(headings).toHaveCount(2)
+  await expect(id).toHaveText('ID')
+  await expect(label).toHaveText('Label')
+}

--- a/packages/e2e/src/extension-detail.feature-json-validation-table-structure.ts
+++ b/packages/e2e/src/extension-detail.feature-json-validation-table-structure.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-json-validation-table-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-json-validation')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.json-validation-test')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.openFeature('JsonValidation')
+
+  const table = Locator('.FeatureContent > table.Table')
+  await expect(table.locator('thead th.TableHeading')).toHaveCount(2)
+  await expect(table.locator('tbody tr')).toHaveCount(1)
+  const cells = table.locator('tbody td.TableCell')
+  const fileMatch = cells.nth(0)
+  const code = fileMatch.locator('code')
+  await expect(cells).toHaveCount(2)
+  await expect(fileMatch).toHaveText('*.test.json')
+  await expect(code).toHaveCount(0)
+}

--- a/packages/e2e/src/extension-detail.feature-programming-languages-table-structure.ts
+++ b/packages/e2e/src/extension-detail.feature-programming-languages-table-structure.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-programming-languages-table-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-programming-languages')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.programming-languages')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.openFeature('ProgrammingLanguages')
+
+  const table = Locator('.FeatureContent > table.Table')
+  await expect(table.locator('thead th.TableHeading')).toHaveCount(5)
+  await expect(table.locator('tbody tr')).toHaveCount(1)
+  const cells = table.locator('tbody td.TableCell')
+  const extension = cells.nth(2).locator('code')
+  await expect(cells).toHaveCount(5)
+  await expect(extension).toHaveText('.css')
+}

--- a/packages/e2e/src/extension-detail.feature-runtime-status-structure.ts
+++ b/packages/e2e/src/extension-detail.feature-runtime-status-structure.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-runtime-status-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-runtime-status')
+  await Extension.addWebExtension(extensionUri)
+  await Extension.activateByEvent('onCommand:runtimeStatus.activate', '', 2)
+  await ExtensionDetail.open('test.runtime-status')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.openFeature('RuntimeStatus')
+
+  const definitionList = Locator('.FeatureContent > dl.RuntimeStatusDefinitionList')
+  await expect(definitionList).toBeVisible()
+  await expect(definitionList.locator('dt')).toHaveCount(4)
+  await expect(definitionList.locator('dd')).toHaveCount(4)
+  await expect(definitionList.locator('dd code')).toHaveText('onCommand:runtimeStatus.activate')
+}

--- a/packages/e2e/src/extension-detail.feature-runtime-status-structure.ts
+++ b/packages/e2e/src/extension-detail.feature-runtime-status-structure.ts
@@ -5,15 +5,15 @@ export const name = 'extension-detail.feature-runtime-status-structure'
 export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
   const extensionUri = import.meta.resolve('../fixtures/extension-runtime-status')
   await Extension.addWebExtension(extensionUri)
-  await Extension.activateByEvent('onCommand:runtimeStatus.activate', '', 2)
   await ExtensionDetail.open('test.runtime-status')
   await ExtensionDetail.selectFeatures()
 
   await ExtensionDetail.openFeature('RuntimeStatus')
 
   const definitionList = Locator('.FeatureContent > dl.RuntimeStatusDefinitionList')
+  const statusTerm = definitionList.locator('dt').nth(0)
+  const statusValue = definitionList.locator('dd').nth(0)
   await expect(definitionList).toBeVisible()
-  await expect(definitionList.locator('dt')).toHaveCount(4)
-  await expect(definitionList.locator('dd')).toHaveCount(4)
-  await expect(definitionList.locator('dd code')).toHaveText('onCommand:runtimeStatus.activate')
+  await expect(statusTerm).toContainText('Status:')
+  await expect(statusValue).toBeVisible()
 }

--- a/packages/e2e/src/extension-detail.feature-settings-table-structure.ts
+++ b/packages/e2e/src/extension-detail.feature-settings-table-structure.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-settings-table-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-settings')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.settings-test')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.openFeature('Settings')
+
+  const table = Locator('.FeatureContent > table.Table')
+  await expect(table.locator('thead tr')).toHaveCount(1)
+  await expect(table.locator('thead th.TableHeading')).toHaveCount(2)
+  await expect(table.locator('tbody tr')).toHaveCount(1)
+  await expect(table.locator('tbody td.TableCell')).toHaveCount(2)
+}

--- a/packages/e2e/src/extension-detail.feature-theme-markdown-structure.ts
+++ b/packages/e2e/src/extension-detail.feature-theme-markdown-structure.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-theme-markdown-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-detail-theme')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.theme-test')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.openFeature('Theme')
+
+  const content = Locator('.FeatureContent')
+  await expect(content.locator(':scope > h1')).toHaveText('Themes')
+  const markdown = content.locator(':scope > .DefaultMarkdown')
+  await expect(markdown).toBeVisible()
+  await expect(markdown.locator('h3')).toHaveText('Color Themes')
+  await expect(markdown.locator('li')).toHaveText('Test')
+}

--- a/packages/e2e/src/extension-detail.feature-webviews-structure.ts
+++ b/packages/e2e/src/extension-detail.feature-webviews-structure.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-webviews-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-webviews')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.webviews-single')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.openFeature('WebViews')
+
+  const webView = Locator('.FeatureWebView')
+  await expect(webView).toHaveCount(1)
+  await expect(webView.locator(':scope > .DefinitionListItem')).toHaveCount(4)
+  await expect(webView.locator('.DefinitionListItem > h2.DefinitionListItemHeading')).toHaveCount(4)
+  await expect(webView.locator('.DefinitionListItem > pre.DefinitionListItemValue')).toHaveCount(4)
+}

--- a/packages/e2e/src/extension-detail.features-hidden-for-changelog.ts
+++ b/packages/e2e/src/extension-detail.features-hidden-for-changelog.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.features-hidden-for-changelog'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.extension-basics')
+  await ExtensionDetail.selectFeatures()
+
+  await ExtensionDetail.selectChangelog()
+
+  const features = Locator('.Features')
+  const changelog = Locator('.ExtensionDetailPanel.Changelog')
+  await expect(features).toHaveCount(0)
+  await expect(changelog).toBeVisible()
+}

--- a/packages/e2e/src/extension-detail.header-builtin-badge.ts
+++ b/packages/e2e/src/extension-detail.header-builtin-badge.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.header-builtin-badge'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-builtin')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-builtin')
+
+  const nameElement = Locator('.ExtensionDetailName')
+  const name = nameElement.locator(':scope > span').nth(0)
+  await expect(name).toHaveText('Test Builtin Extension')
+  const badge = nameElement.locator('.ExtensionDetailNameBadge')
+  await expect(badge).toBeVisible()
+  await expect(badge).toHaveText('builtin')
+}

--- a/packages/e2e/src/extension-detail.header-details-structure.ts
+++ b/packages/e2e/src/extension-detail.header-details-structure.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.header-details-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const details = Locator('.ExtensionDetailHeaderDetails')
+  await expect(details.locator(':scope > .ExtensionDetailName')).toHaveCount(1)
+  await expect(details.locator(':scope > .ExtensionDetailDescription')).toHaveCount(1)
+  await expect(details.locator(':scope > .ExtensionDetailMetadata')).toHaveCount(1)
+  await expect(details.locator(':scope > .ExtensionDetailHeaderActions')).toHaveCount(1)
+}

--- a/packages/e2e/src/extension-detail.header-name-badge-hidden.ts
+++ b/packages/e2e/src/extension-detail.header-name-badge-hidden.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.header-name-badge-hidden'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const nameElement = Locator('.ExtensionDetailName')
+  await expect(nameElement).toHaveText('Test')
+  await expect(nameElement.locator('.ExtensionDetailNameBadge')).toHaveCount(0)
+}

--- a/packages/e2e/src/extension-detail.header-primary-button-styles.ts
+++ b/packages/e2e/src/extension-detail.header-primary-button-styles.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.header-primary-button-styles'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const actions = Locator('.ExtensionDetailHeaderActions')
+  await expect(actions.locator('button.Button.ButtonPrimary')).toHaveCount(2)
+}

--- a/packages/e2e/src/extension-detail.installation-code-values.ts
+++ b/packages/e2e/src/extension-detail.installation-code-values.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.installation-code-values'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const installation = Locator('.AdditionalDetailsEntry:nth-of-type(1)')
+  const codeValues = installation.locator('code.MoreInfoEntryValue')
+  const identifier = codeValues.nth(0)
+  const version = codeValues.nth(1)
+  await expect(codeValues).toHaveCount(2)
+  await expect(identifier).toHaveText('test.extension-basics')
+  await expect(version).toHaveText('n/a')
+}

--- a/packages/e2e/src/extension-detail.installation-row-order.ts
+++ b/packages/e2e/src/extension-detail.installation-row-order.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.installation-row-order'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const keys = Locator('.AdditionalDetailsEntry:nth-of-type(1) .MoreInfoEntryKey')
+  const identifier = keys.nth(0)
+  const version = keys.nth(1)
+  const lastUpdated = keys.nth(2)
+  const size = keys.nth(3)
+  await expect(keys).toHaveCount(4)
+  await expect(identifier).toHaveText('Identifier')
+  await expect(version).toHaveText('Version')
+  await expect(lastUpdated).toHaveText('Last Updated')
+  await expect(size).toHaveText('Size')
+}

--- a/packages/e2e/src/extension-detail.installation-row-stripes.ts
+++ b/packages/e2e/src/extension-detail.installation-row-stripes.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.installation-row-stripes'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const rows = Locator('.AdditionalDetailsEntry:nth-of-type(1) .MoreInfoEntry')
+  const first = rows.nth(0)
+  const second = rows.nth(1)
+  const third = rows.nth(2)
+  const fourth = rows.nth(3)
+  await expect(first).toHaveAttribute('class', 'MoreInfoEntry MoreInfoEntryOdd')
+  await expect(second).toHaveAttribute('class', 'MoreInfoEntry')
+  await expect(third).toHaveAttribute('class', 'MoreInfoEntry MoreInfoEntryOdd')
+  await expect(fourth).toHaveAttribute('class', 'MoreInfoEntry')
+}

--- a/packages/e2e/src/extension-detail.marketplace-row-order.ts
+++ b/packages/e2e/src/extension-detail.marketplace-row-order.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.marketplace-row-order'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const keys = Locator('.AdditionalDetailsEntry:nth-of-type(2) .MoreInfoEntryKey')
+  const published = keys.nth(0)
+  const lastReleased = keys.nth(1)
+  await expect(keys).toHaveCount(2)
+  await expect(published).toHaveText('Published')
+  await expect(lastReleased).toHaveText('Last Released')
+}

--- a/packages/e2e/src/extension-detail.marketplace-row-stripes.ts
+++ b/packages/e2e/src/extension-detail.marketplace-row-stripes.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.marketplace-row-stripes'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const rows = Locator('.AdditionalDetailsEntry:nth-of-type(2) .MoreInfoEntry')
+  const first = rows.nth(0)
+  const second = rows.nth(1)
+  await expect(first).toHaveAttribute('class', 'MoreInfoEntry MoreInfoEntryOdd')
+  await expect(second).toHaveAttribute('class', 'MoreInfoEntry')
+}

--- a/packages/e2e/src/extension-detail.marketplace-value-elements.ts
+++ b/packages/e2e/src/extension-detail.marketplace-value-elements.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.marketplace-value-elements'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const marketplace = Locator('.AdditionalDetailsEntry:nth-of-type(2)')
+  const values = marketplace.locator('dd.MoreInfoEntryValue')
+  const published = values.nth(0)
+  const lastReleased = values.nth(1)
+  await expect(values).toHaveCount(2)
+  await expect(published).toHaveText('n/a')
+  await expect(lastReleased).toHaveText('n/a')
+}

--- a/packages/e2e/src/extension-detail.metadata-structure.ts
+++ b/packages/e2e/src/extension-detail.metadata-structure.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.metadata-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const metadata = Locator('.ExtensionDetailMetadata')
+  await expect(metadata.locator(':scope > .ExtensionDetailStatistic')).toHaveCount(2)
+  await expect(metadata.locator(':scope > .ExtensionDetailDownloadCount')).toHaveCount(1)
+  await expect(metadata.locator(':scope > .ExtensionDetailRating')).toHaveCount(1)
+}

--- a/packages/e2e/src/extension-detail.metadata-values.ts
+++ b/packages/e2e/src/extension-detail.metadata-values.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.metadata-values'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const downloadCount = Locator('.ExtensionDetailDownloadCount')
+  const rating = Locator('.ExtensionDetailRating')
+  await expect(downloadCount).toHaveText('12,345')
+  await expect(rating).toHaveText('4.8')
+}

--- a/packages/e2e/src/extension-detail.readme-document-role.ts
+++ b/packages/e2e/src/extension-detail.readme-document-role.ts
@@ -1,6 +1,6 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'extension-detail.settings-button-hidden'
+export const name = 'extension-detail.readme-document-role'
 
 export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
   const extensionUri = import.meta.resolve('../fixtures/extension-basics')
@@ -8,6 +8,7 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
 
   await ExtensionDetail.open('test.extension-basics')
 
-  const settingsButton = Locator('.ExtensionDetailHeaderActions .SettingsButton')
-  await expect(settingsButton).toHaveCount(0)
+  const readme = Locator('.ExtensionDetailPanel .Markdown')
+  await expect(readme).toBeVisible()
+  await expect(readme).toHaveAttribute('role', 'document')
 }

--- a/packages/e2e/src/extension-detail.readme-heading-structure.ts
+++ b/packages/e2e/src/extension-detail.readme-heading-structure.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.readme-heading-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const markdown = Locator('.ExtensionDetailPanel > .Markdown')
+  await expect(markdown.locator(':scope > h1')).toHaveCount(1)
+  await expect(markdown.locator(':scope > h1')).toHaveText('test readme')
+}

--- a/packages/e2e/src/extension-detail.readme-rich-structure.ts
+++ b/packages/e2e/src/extension-detail.readme-rich-structure.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.readme-rich-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-readme-rich')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-readme-rich')
+
+  const markdown = Locator('.Markdown')
+  await expect(markdown.locator('h1')).toHaveText('Rich Readme')
+  await expect(markdown.locator('h2')).toHaveText('Settings')
+  await expect(markdown.locator('li')).toHaveCount(3)
+  const link = markdown.locator('a')
+  await expect(link).toHaveAttribute('href', 'https://example.com/rich-readme')
+}

--- a/packages/e2e/src/extension-detail.resource-icons.ts
+++ b/packages/e2e/src/extension-detail.resource-icons.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.resource-icons'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-resource-github')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-resource-github')
+
+  const links = Locator('.Resources > a.Resource')
+  const issuesIcon = links.nth(0).locator('.MaskIconLinkExternal')
+  const repositoryIcon = links.nth(1).locator('.MaskIconRepo')
+  const licenseIcon = links.nth(2).locator('.MaskIconLinkExternal')
+  await expect(links).toHaveCount(3)
+  await expect(issuesIcon).toHaveCount(1)
+  await expect(repositoryIcon).toHaveCount(1)
+  await expect(licenseIcon).toHaveCount(1)
+}

--- a/packages/e2e/src/extension-detail.resources-fallback-elements.ts
+++ b/packages/e2e/src/extension-detail.resources-fallback-elements.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.resources-fallback-elements'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const resources = Locator('.Resources')
+  await expect(resources.locator(':scope > div.Resource')).toHaveCount(4)
+  await expect(resources.locator(':scope > a.Resource')).toHaveCount(0)
+}

--- a/packages/e2e/src/extension-detail.root-structure.ts
+++ b/packages/e2e/src/extension-detail.root-structure.ts
@@ -9,7 +9,7 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await ExtensionDetail.open('test.extension-basics')
 
   const header = Locator('.ExtensionDetail > .ExtensionDetailHeader')
-  const tabs = Locator('.ExtensionDetail > .ExtensionDetailTabs')
+  const tabs = Locator('.ExtensionDetailTabs')
   const panel = Locator('.ExtensionDetail > .ExtensionDetailPanel')
   await expect(header).toHaveCount(1)
   await expect(tabs).toHaveCount(1)

--- a/packages/e2e/src/extension-detail.root-structure.ts
+++ b/packages/e2e/src/extension-detail.root-structure.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.root-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const header = Locator('.ExtensionDetail > .ExtensionDetailHeader')
+  const tabs = Locator('.ExtensionDetail > .ExtensionDetailTabs')
+  const panel = Locator('.ExtensionDetail > .ExtensionDetailPanel')
+  await expect(header).toHaveCount(1)
+  await expect(tabs).toHaveCount(1)
+  await expect(panel).toHaveCount(1)
+}

--- a/packages/e2e/src/extension-detail.settings-button-hidden.ts
+++ b/packages/e2e/src/extension-detail.settings-button-hidden.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.settings-button-hidden'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const settingsButton = Locator('.ExtensionDetailHeaderActions .SettingsButton')
+  await expect(settingsButton).toHaveCount(0)
+}

--- a/packages/e2e/src/extension-detail.sidebar-section-order.ts
+++ b/packages/e2e/src/extension-detail.sidebar-section-order.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.sidebar-section-order'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const headings = Locator('.AdditionalDetails > .AdditionalDetailsEntry > .AdditionalDetailsTitle')
+  const installation = headings.nth(0)
+  const marketplace = headings.nth(1)
+  const categories = headings.nth(2)
+  const resources = headings.nth(3)
+  await expect(headings).toHaveCount(4)
+  await expect(installation).toHaveText('Installation')
+  await expect(marketplace).toHaveText('Marketplace')
+  await expect(categories).toHaveText('Categories')
+  await expect(resources).toHaveText('Resources')
+}

--- a/packages/e2e/src/extension-detail.sidebar-section-structure.ts
+++ b/packages/e2e/src/extension-detail.sidebar-section-structure.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.sidebar-section-structure'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const sections = Locator('.AdditionalDetails > .AdditionalDetailsEntry')
+  await expect(sections).toHaveCount(4)
+  await expect(sections.locator(':scope > .AdditionalDetailsTitle')).toHaveCount(4)
+}

--- a/packages/e2e/src/extension-detail.tabs-changelog-selection.ts
+++ b/packages/e2e/src/extension-detail.tabs-changelog-selection.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.tabs-changelog-selection'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.extension-basics')
+
+  await ExtensionDetail.selectChangelog()
+
+  const details = Locator('.ExtensionDetailTab[name="Details"]')
+  const features = Locator('.ExtensionDetailTab[name="Features"]')
+  const changelog = Locator('.ExtensionDetailTab[name="Changelog"]')
+  await expect(details).toHaveAttribute('aria-selected', 'false')
+  await expect(features).toHaveAttribute('aria-selected', 'false')
+  await expect(changelog).toHaveAttribute('aria-selected', 'true')
+}

--- a/packages/e2e/src/extension-detail.tabs-features-selection.ts
+++ b/packages/e2e/src/extension-detail.tabs-features-selection.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.tabs-features-selection'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.extension-basics')
+
+  await ExtensionDetail.selectFeatures()
+
+  const details = Locator('.ExtensionDetailTab[name="Details"]')
+  const features = Locator('.ExtensionDetailTab[name="Features"]')
+  const changelog = Locator('.ExtensionDetailTab[name="Changelog"]')
+  await expect(details).toHaveAttribute('aria-selected', 'false')
+  await expect(features).toHaveAttribute('aria-selected', 'true')
+  await expect(changelog).toHaveAttribute('aria-selected', 'false')
+}

--- a/packages/e2e/src/extension-detail.tabs-initial-selection.ts
+++ b/packages/e2e/src/extension-detail.tabs-initial-selection.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.tabs-initial-selection'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+
+  await ExtensionDetail.open('test.extension-basics')
+
+  const details = Locator('.ExtensionDetailTab[name="Details"]')
+  const features = Locator('.ExtensionDetailTab[name="Features"]')
+  const changelog = Locator('.ExtensionDetailTab[name="Changelog"]')
+  await expect(details).toHaveAttribute('aria-selected', 'true')
+  await expect(features).toHaveAttribute('aria-selected', 'false')
+  await expect(changelog).toHaveAttribute('aria-selected', 'false')
+}

--- a/packages/e2e/src/extension-detail.tabs-persist.ts
+++ b/packages/e2e/src/extension-detail.tabs-persist.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.tabs-persist'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.extension-basics')
+
+  await ExtensionDetail.selectFeatures()
+  await ExtensionDetail.selectChangelog()
+
+  const tabs = Locator('.ExtensionDetailTabs')
+  await expect(tabs).toBeVisible()
+  await expect(tabs.locator('.ExtensionDetailTab')).toHaveCount(3)
+}

--- a/packages/e2e/src/extension-detail.tabs-selected-class.ts
+++ b/packages/e2e/src/extension-detail.tabs-selected-class.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.tabs-selected-class'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = import.meta.resolve('../fixtures/extension-basics')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.extension-basics')
+
+  await ExtensionDetail.selectFeatures()
+
+  const details = Locator('.ExtensionDetailTab[name="Details"]')
+  const features = Locator('.ExtensionDetailTab[name="Features"]')
+  const changelog = Locator('.ExtensionDetailTab[name="Changelog"]')
+  await expect(details).toHaveAttribute('class', 'ExtensionDetailTab')
+  await expect(features).toHaveAttribute('class', 'ExtensionDetailTab ExtensionDetailTabSelected')
+  await expect(changelog).toHaveAttribute('class', 'ExtensionDetailTab')
+}


### PR DESCRIPTION
Adds 40 focused extension-detail-view e2e tests covering header metadata, tabs, sidebar details, feature content, README rendering, and changelog rendering.