### PR TITLE
fix: accept https json validation schemas

### DIFF
--- a/packages/e2e/fixtures/extension-json-validation-https-schema/extension.json
+++ b/packages/e2e/fixtures/extension-json-validation-https-schema/extension.json
@@ -1,0 +1,11 @@
+{
+  "id": "test.json-validation-https-schema",
+  "name": "Test Json Validation HTTPS Schema",
+  "description": "Test Json Validation HTTPS Schema",
+  "jsonValidation": [
+    {
+      "fileMatch": "*.test.json",
+      "schema": "https://json.schemastore.org/prettierrc"
+    }
+  ]
+}

--- a/packages/e2e/src/extension-detail.feature-json-validation-https-schema.ts
+++ b/packages/e2e/src/extension-detail.feature-json-validation-https-schema.ts
@@ -1,0 +1,24 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-detail.feature-json-validation-https-schema'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  // arrange
+  const extensionUri = import.meta.resolve('../fixtures/extension-json-validation-https-schema')
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.json-validation-https-schema')
+  await ExtensionDetail.selectFeatures()
+
+  // act
+  await ExtensionDetail.openFeature('JsonValidation')
+
+  // assert
+  const table = Locator('.FeatureContent .Table')
+  await expect(table).toBeVisible()
+  const schemaCell = table.locator('tbody td').nth(1)
+  await expect(schemaCell).toHaveText('https://json.schemastore.org/prettierrc')
+  await expect(schemaCell).toHaveAttribute('class', 'TableCell')
+  const link = schemaCell.locator('a')
+  await expect(link).toBeVisible()
+  await expect(link).toHaveAttribute('href', 'https://json.schemastore.org/prettierrc')
+}

--- a/packages/extension-detail-view-worker/src/parts/GetJsonValidationInfos/GetJsonValidationInfos.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetJsonValidationInfos/GetJsonValidationInfos.ts
@@ -34,7 +34,8 @@ export const getJsonValidationInfos = async (extensionUri: string, validations: 
       })
     } else if (schemaLinkUrl) {
       // TODO maybe better use filesystem.exists
-      if (await existsJson(schemaLinkUrl)) {
+      const isValid = schema.startsWith('https://') || (await existsJson(schemaLinkUrl))
+      if (isValid) {
         validationInfos.push({
           errorMessage: '',
           fileMatch,

--- a/packages/extension-detail-view-worker/test/GetJsonValidationInfos.test.ts
+++ b/packages/extension-detail-view-worker/test/GetJsonValidationInfos.test.ts
@@ -61,7 +61,7 @@ test('handles validation with invalid link', async () => {
   })
 })
 
-test('handles validation with valid external schema that exists', async () => {
+test('handles validation with valid https schema without checking whether it exists', async () => {
   const extensionUri: string = 'https://example.com/extension'
   const schemaUrl: string = 'https://json.schemastore.org/package.json'
   const validations: readonly any[] = [
@@ -70,10 +70,6 @@ test('handles validation with valid external schema that exists', async () => {
       schema: schemaUrl,
     },
   ]
-
-  mockFetch.mockResolvedValueOnce({
-    ok: true,
-  } as Response)
 
   const result: readonly JsonValidationInfo[] = await getJsonValidationInfos(extensionUri, validations)
 
@@ -85,12 +81,12 @@ test('handles validation with valid external schema that exists', async () => {
     schemaUrl: schemaUrl,
     stringValue: schemaUrl,
   })
-  expect(mockFetch).toHaveBeenCalledWith(schemaUrl, { method: 'HEAD' })
+  expect(mockFetch).not.toHaveBeenCalled()
 })
 
-test('handles validation with valid external schema that does not exist', async () => {
+test('handles validation with valid http schema that does not exist', async () => {
   const extensionUri: string = 'https://example.com/extension'
-  const schemaUrl: string = 'https://example.com/nonexistent.json'
+  const schemaUrl: string = 'http://example.com/nonexistent.json'
   const validations: readonly any[] = [
     {
       fileMatch: '*.json',
@@ -114,9 +110,9 @@ test('handles validation with valid external schema that does not exist', async 
   })
 })
 
-test('handles validation with valid external schema when fetch throws', async () => {
+test('handles validation with valid http schema when fetch throws', async () => {
   const extensionUri: string = 'https://example.com/extension'
-  const schemaUrl: string = 'https://example.com/schema.json'
+  const schemaUrl: string = 'http://example.com/schema.json'
   const validations: readonly any[] = [
     {
       fileMatch: '*.json',


### PR DESCRIPTION
Summary:
- treat valid HTTPS JSON schema URLs as valid without probing the remote server
- preserve missing-schema diagnostics for relative and HTTP schema links
- add unit and end-to-end regression coverage