### PR TITLE
fix: select available extension feature

### DIFF
--- a/packages/extension-detail-view-worker/src/parts/FeatureRegistry/FeatureRegistry.ts
+++ b/packages/extension-detail-view-worker/src/parts/FeatureRegistry/FeatureRegistry.ts
@@ -22,11 +22,13 @@ export const register = <Key extends keyof ExtensionDetailState>(feature: Featur
 export const getFeatures = (selectedFeature: string, extension: any): readonly Feature[] => {
   const allFeatures = Object.values(features)
   const enabledFeatures = allFeatures.filter((item) => item.isEnabled(extension))
+  const hasSelectedFeature = enabledFeatures.some((item) => item.id === selectedFeature)
+  const actualSelectedFeature = hasSelectedFeature ? selectedFeature : enabledFeatures[0]?.id
   const converted: readonly Feature[] = enabledFeatures.map((item) => {
     return {
       id: item.id,
       label: item.getLabel(),
-      selected: item.id === selectedFeature,
+      selected: item.id === actualSelectedFeature,
     }
   })
 

--- a/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
@@ -103,6 +103,7 @@ const loadContentInternal = async (
   const size = GetViewletSize.getViewletSize(width)
   const { changelogScrollTop, readmeScrollTop, selectedFeature, selectedTab } = RestoreState.restoreState(savedState)
   const features = FeatureRegistry.getFeatures(selectedFeature || InputName.Theme, extension)
+  const actualSelectedFeature = features.find((feature) => feature.selected)?.id || ''
   const hasFeatures = features.length > 0
   const hasGithubReleases = Boolean(getGithubRepository(extension))
   const tabs: readonly Tab[] = GetTabs.getTabs(selectedTab, hasReadme, hasFeatures, hasChangelog || hasGithubReleases)
@@ -170,6 +171,7 @@ const loadContentInternal = async (
     resources,
     scrollSource: InputSource.Script,
     scrollToTopButtonEnabled: true,
+    selectedFeature: actualSelectedFeature,
     selectedTab,
     settingsButtonEnabled: true,
     showSideBar,

--- a/packages/extension-detail-view-worker/test/FeatureRegistry.test.ts
+++ b/packages/extension-detail-view-worker/test/FeatureRegistry.test.ts
@@ -82,6 +82,42 @@ test('getFeatures marks selected feature correctly', () => {
   expect(unselectedFeature?.selected).toBe(false)
 })
 
+test('getFeatures selects the first enabled feature when selected feature is unavailable', () => {
+  const feature1 = {
+    getDetails: jest.fn(async (): Promise<object> => ({})),
+    getLabel: (): string => 'Feature 1',
+    getVirtualDom: jest.fn((): any[] => []),
+    id: 'feature-1',
+    isEnabled: jest.fn((): boolean => true),
+  }
+
+  const feature2 = {
+    getDetails: jest.fn(async (): Promise<object> => ({})),
+    getLabel: (): string => 'Feature 2',
+    getVirtualDom: jest.fn((): any[] => []),
+    id: 'feature-2',
+    isEnabled: jest.fn((): boolean => true),
+  }
+
+  register(feature1)
+  register(feature2)
+
+  const features = getFeatures('unavailable-feature', {})
+
+  expect(features).toEqual([
+    {
+      id: 'feature-1',
+      label: 'Feature 1',
+      selected: true,
+    },
+    {
+      id: 'feature-2',
+      label: 'Feature 2',
+      selected: false,
+    },
+  ])
+})
+
 test('getFeatureDetailsHandler returns handler for existing feature', () => {
   const mockHandler = jest.fn(async (): Promise<object> => ({}))
   const mockFeature = {

--- a/packages/extension-detail-view-worker/test/LoadContent.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadContent.test.ts
@@ -1,7 +1,8 @@
-import { beforeAll, expect, test } from '@jest/globals'
+import { afterEach, beforeAll, expect, jest, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../src/parts/ExtensionDetailState/ExtensionDetailState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { clearRegistry, register } from '../src/parts/FeatureRegistry/FeatureRegistry.ts'
 import * as FileSystemWorker from '../src/parts/FileSystemWorker/FileSystemWorker.ts'
 import * as LoadContent from '../src/parts/LoadContent/LoadContent.ts'
 import * as MarkdownWorker from '../src/parts/MarkdownWorker/MarkdownWorker.ts'
@@ -14,6 +15,8 @@ beforeAll(() => {
     protocol: 'https:',
   }
 })
+
+afterEach(clearRegistry)
 
 test('loadContent - successful load', async () => {
   const mockExtension: any = {
@@ -239,7 +242,7 @@ test('loadContent - with builtin extension', async () => {
   expect(mockMarkdownRpc.invocations.length).toBeGreaterThan(0)
 })
 
-test('loadContent - with saved state', async () => {
+test('loadContent - selects first available feature when saved feature is unavailable', async () => {
   const mockExtension: any = {
     builtin: false,
     description: 'A test extension',
@@ -293,14 +296,41 @@ test('loadContent - with saved state', async () => {
     uri: 'extension-detail://test-extension',
   }
 
+  register({
+    getDetails: jest.fn(async (): Promise<object> => ({})),
+    getLabel: (): string => 'Feature 1',
+    getVirtualDom: jest.fn((): any[] => []),
+    id: 'feature-1',
+    isEnabled: jest.fn((): boolean => true),
+  })
+  register({
+    getDetails: jest.fn(async (): Promise<object> => ({})),
+    getLabel: (): string => 'Feature 2',
+    getVirtualDom: jest.fn((): any[] => []),
+    id: 'feature-2',
+    isEnabled: jest.fn((): boolean => true),
+  })
+
   const savedState: any = {
-    selectedFeature: 'commands',
+    selectedFeature: 'unavailable-feature',
     selectedTab: 'details',
   }
 
   const result: ExtensionDetailState = await LoadContent.loadContent(state, 1, savedState)
 
-  expect(result.selectedFeature).toBe('')
+  expect(result.selectedFeature).toBe('feature-1')
+  expect(result.features).toEqual([
+    {
+      id: 'feature-1',
+      label: 'Feature 1',
+      selected: true,
+    },
+    {
+      id: 'feature-2',
+      label: 'Feature 2',
+      selected: false,
+    },
+  ])
   expect(result.selectedTab).toBe('details')
   expect(mockRendererRpc.invocations).toEqual([
     ['ExtensionManagement.getExtension', 'test-extension'],


### PR DESCRIPTION
## Summary

- preserve the restored feature when it is available
- fall back to the first enabled feature when the restored selection is unavailable
- keep the selected feature state and feature list in sync while loading extension details