### PR TITLE
fix: show extension detail sidebar initially

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2944,9 +2944,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.22.0.tgz",
-      "integrity": "sha512-yjT2rnsk+1jRoda5ZnU7ENjunjvqfsa6Lr4ydO+88K/dE0ifoZQN3VtH+8eeZBCMTw8sBT71X/d4aM1aX5b2Vg==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.23.0.tgz",
+      "integrity": "sha512-hjkqo7QLQl7pL2c+rH54q0/8dSpKDSfF6/3BvBAS2NsSpvtCnab3Ew4bhVyMJrw1c9RnwcC2pmy6iDPtPpz0IQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
@@ -3886,14 +3886,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.42.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.42.0.tgz",
-      "integrity": "sha512-5/G0T87nC3aKRujuLJSpSsG0jPdXmrwDqRX3rHNmUWh7FaMPC0SoqBqenMTy2V+EHqnX0LRFyC6FO5LPwoPFgQ==",
+      "version": "9.43.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.43.0.tgz",
+      "integrity": "sha512-STUNoKvOO9D90p2sk3PXJKwVwEGwArBPB33pCImfBg6HrTP2Q/OPZMzi4HXwseNfusOO6xPlaiXKEND1fgwlOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.22.0",
+        "@lvce-editor/constants": "^5.23.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
@@ -16447,7 +16447,7 @@
         "@lvce-editor/constants": "^5.20.0",
         "@lvce-editor/i18n": "^2.5.0",
         "@lvce-editor/rpc": "^6.10.0",
-        "@lvce-editor/rpc-registry": "^9.42.0",
+        "@lvce-editor/rpc-registry": "^9.43.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
         "@lvce-editor/virtual-dom-worker": "^11.8.1",

--- a/packages/extension-detail-view-worker/src/parts/Create/Create.ts
+++ b/packages/extension-detail-view-worker/src/parts/Create/Create.ts
@@ -1,5 +1,6 @@
 import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
 import * as ExtensionDetailStates from '../ExtensionDetailStates/ExtensionDetailStates.ts'
+import { getResponsiveLayout } from '../GetResponsiveLayout/GetResponsiveLayout.ts'
 
 export const create = (uid: number, uri: string, x: number, y: number, width: number, height: number, platform: number, assetDir: string): void => {
   const state: ExtensionDetailState = {
@@ -49,8 +50,7 @@ export const create = (uid: number, uri: string, x: number, y: number, width: nu
     locationProtocol: '',
     marketplaceEntries: [],
     name: '',
-    paddingLeft: 0,
-    paddingRight: 0,
+    ...getResponsiveLayout(width),
     platform,
     programmingLanguages: [],
     rating: 'n/a',
@@ -64,9 +64,7 @@ export const create = (uid: number, uri: string, x: number, y: number, width: nu
     settings: [],
     settingsButtonEnabled: false,
     showAdditionalDetailsBreakpoint: 700,
-    showSideBar: true,
     showSizeLink: false,
-    sideBarWidth: 0,
     sizeOnDisk: 0,
     sizeValue: 0,
     status: 0,

--- a/packages/extension-detail-view-worker/src/parts/GetResponsiveLayout/GetResponsiveLayout.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetResponsiveLayout/GetResponsiveLayout.ts
@@ -1,0 +1,19 @@
+import { getPadding, getSideBarWidth } from '../GetPadding/GetPadding.ts'
+
+export interface ResponsiveLayout {
+  readonly paddingLeft: number
+  readonly paddingRight: number
+  readonly showSideBar: boolean
+  readonly sideBarWidth: number
+}
+
+export const getResponsiveLayout = (width: number): ResponsiveLayout => {
+  const padding = getPadding(width)
+  const sideBarWidth = getSideBarWidth(width)
+  return {
+    paddingLeft: padding,
+    paddingRight: padding,
+    showSideBar: sideBarWidth > 0,
+    sideBarWidth,
+  }
+}

--- a/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
@@ -19,7 +19,7 @@ import { getExtensionUri } from '../GetExtensionUri/GetExtensionUri.ts'
 import { getGithubRepository } from '../GetGithubRepository/GetGithubRepository.ts'
 import { getLinkProtectionEnabled } from '../GetLinkProtectionEnabled/GetLinkProtectionEnabled.ts'
 import { getMarkdownVirtualDom } from '../GetMarkdownVirtualDom/GetMarkdownVirtualDom.ts'
-import { getPadding, getSideBarWidth } from '../GetPadding/GetPadding.ts'
+import { getResponsiveLayout } from '../GetResponsiveLayout/GetResponsiveLayout.ts'
 import { getSyntaxLanguages } from '../GetSyntaxLanguages/GetSyntaxLanguages.ts'
 import * as GetTabs from '../GetTabs/GetTabs.ts'
 import * as GetViewletSize from '../GetViewletSize/GetViewletSize.ts'
@@ -122,9 +122,6 @@ const loadContentInternal = async (
     created,
     lastUpdated,
   )
-  const padding = getPadding(width)
-  const sideBarWidth = getSideBarWidth(width)
-  const showSideBar = sideBarWidth > 0
   const linkProtectionEnabled = await getLinkProtectionEnabled()
   return {
     ...state,
@@ -162,8 +159,7 @@ const loadContentInternal = async (
     locationProtocol,
     marketplaceEntries,
     name,
-    paddingLeft: padding,
-    paddingRight: padding,
+    ...getResponsiveLayout(width),
     platform,
     rating,
     readmeScrollTop,
@@ -174,9 +170,7 @@ const loadContentInternal = async (
     selectedFeature: actualSelectedFeature,
     selectedTab,
     settingsButtonEnabled: true,
-    showSideBar,
     showSizeLink,
-    sideBarWidth,
     sizeOnDisk: size,
     sizeValue,
     tabs: enabledTabs,

--- a/packages/extension-detail-view-worker/src/parts/LoadContent2/LoadContent2.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadContent2/LoadContent2.ts
@@ -1,7 +1,20 @@
 import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
+import * as ExtensionDetailStates from '../ExtensionDetailStates/ExtensionDetailStates.ts'
+import { getResponsiveLayout } from '../GetResponsiveLayout/GetResponsiveLayout.ts'
 import * as LoadContent from '../LoadContent/LoadContent.ts'
+
+export const applyLatestResponsiveLayout = (state: ExtensionDetailState): ExtensionDetailState => {
+  const { uid } = state
+  const { width } = ExtensionDetailStates.get(uid).newState
+  return {
+    ...state,
+    ...getResponsiveLayout(width),
+    width,
+  }
+}
 
 export const loadContent2 = async (state: ExtensionDetailState, savedState: unknown, isTest: boolean = false): Promise<ExtensionDetailState> => {
   const { platform } = state
-  return LoadContent.loadContent(state, platform, savedState, isTest)
+  const loadedState = await LoadContent.loadContent(state, platform, savedState, isTest)
+  return applyLatestResponsiveLayout(loadedState)
 }

--- a/packages/extension-detail-view-worker/src/parts/Resize/Resize.ts
+++ b/packages/extension-detail-view-worker/src/parts/Resize/Resize.ts
@@ -1,17 +1,11 @@
 import type { Dimensions } from '../Dimensions/Dimensions.ts'
 import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
-import { getPadding, getSideBarWidth } from '../GetPadding/GetPadding.ts'
+import { getResponsiveLayout } from '../GetResponsiveLayout/GetResponsiveLayout.ts'
 
 export const resize = (state: ExtensionDetailState, dimensions: Dimensions): ExtensionDetailState => {
-  const padding = getPadding(dimensions.width)
-  const sideBarWidth = getSideBarWidth(dimensions.width)
-  const showSideBar = sideBarWidth > 0
   return {
     ...state,
     ...dimensions,
-    paddingLeft: padding,
-    paddingRight: padding,
-    showSideBar,
-    sideBarWidth,
+    ...getResponsiveLayout(dimensions.width),
   }
 }

--- a/packages/extension-detail-view-worker/test/Create.test.ts
+++ b/packages/extension-detail-view-worker/test/Create.test.ts
@@ -2,12 +2,12 @@ import { test, expect } from '@jest/globals'
 import { create } from '../src/parts/Create/Create.ts'
 import * as ExtensionDetailStates from '../src/parts/ExtensionDetailStates/ExtensionDetailStates.ts'
 
-test('create initializes extension detail state', () => {
+test('create initializes responsive layout from the initial width', () => {
   const uid = 123
   const uri = 'extension-detail://test-extension'
   const x = 100
   const y = 200
-  const width = 500
+  const width = 800
   const height = 600
   const platform = 1
   const assetDir = '/test/assets'
@@ -15,5 +15,11 @@ test('create initializes extension detail state', () => {
   create(uid, uri, x, y, width, height, platform, assetDir)
 
   const state = ExtensionDetailStates.get(uid)
-  expect(state).toBeDefined()
+  expect(state.newState).toMatchObject({
+    paddingLeft: 10,
+    paddingRight: 10,
+    showSideBar: true,
+    sideBarWidth: 335,
+    width: 800,
+  })
 })

--- a/packages/extension-detail-view-worker/test/LoadContent2.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadContent2.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@jest/globals'
+import type { ExtensionDetailState } from '../src/parts/ExtensionDetailState/ExtensionDetailState.ts'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as ExtensionDetailStates from '../src/parts/ExtensionDetailStates/ExtensionDetailStates.ts'
+import { applyLatestResponsiveLayout } from '../src/parts/LoadContent2/LoadContent2.ts'
+import { resize } from '../src/parts/Resize/Resize.ts'
+
+test('applyLatestResponsiveLayout preserves a newer responsive layout when loading finishes', () => {
+  const initialState: ExtensionDetailState = {
+    ...createDefaultState(),
+    uid: 1,
+    width: 400,
+  }
+  ExtensionDetailStates.set(initialState.uid, initialState, initialState)
+
+  const resizedState = resize(initialState, { height: 600, width: 800, x: 0, y: 0 })
+  ExtensionDetailStates.set(initialState.uid, initialState, resizedState)
+  const result = applyLatestResponsiveLayout({
+    ...initialState,
+    name: 'Loaded Extension',
+  })
+
+  expect(result).toMatchObject({
+    name: 'Loaded Extension',
+    paddingLeft: 10,
+    paddingRight: 10,
+    showSideBar: true,
+    sideBarWidth: 335,
+    width: 800,
+  })
+})


### PR DESCRIPTION
Fix the extension detail view so its responsive sidebar layout is initialized from the available width.

Preserve the latest responsive dimensions when asynchronous content loading finishes, preventing a stale load result from hiding the sidebar until the next window resize.