### PR TITLE
fix: show disabled runtime status

### DIFF
--- a/packages/extension-detail-view-worker/src/parts/FeatureRuntimeStatusVirtualDom/FeatureRuntimeStatusVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/FeatureRuntimeStatusVirtualDom/FeatureRuntimeStatusVirtualDom.ts
@@ -7,6 +7,11 @@ import * as GetActivationTimeVirtualDom from '../GetActivationTimeVirtualDom/Get
 import * as GetFeatureContentHeadingVirtualDom from '../GetFeatureContentHeadingVirtualDom/GetFeatureContentHeadingVirtualDom.ts'
 import * as GetRuntimeActivationEventVirtualDom from '../GetRuntimeActivationEventVirtualDom/GetRuntimeActivationEventVirtualDom.ts'
 import * as GetStatusVirtualDom from '../GetStatusVirtualDom/GetStatusVirtualDom.ts'
+import * as RuntimeStatusType from '../RuntimeStatusType/RuntimeStatusType.ts'
+
+interface FeatureRuntimeStatusViewState extends FeatureRuntimeStatusState {
+  readonly disabled?: boolean
+}
 
 const featureContentNode: VirtualDomNode = {
   childCount: 2,
@@ -26,8 +31,9 @@ const getChildCount = (status: number, activationEvent: string, activationTime: 
   return childCount
 }
 
-export const getRuntimeStatusVirtualDom = (state: FeatureRuntimeStatusState): readonly VirtualDomNode[] => {
-  const { activationTime, importTime, status, wasActivatedByEvent } = state
+export const getRuntimeStatusVirtualDom = (state: FeatureRuntimeStatusViewState): readonly VirtualDomNode[] => {
+  const { activationTime, disabled, importTime, status, wasActivatedByEvent } = state
+  const displayedStatus = disabled ? RuntimeStatusType.Disabled : status
   const heading = ExtensionDetailStrings.runtimeStatus()
   const childCount = getChildCount(status, wasActivatedByEvent, activationTime, importTime)
   return [
@@ -38,7 +44,7 @@ export const getRuntimeStatusVirtualDom = (state: FeatureRuntimeStatusState): re
       className: 'RuntimeStatusDefinitionList',
       type: VirtualDomElements.Dl,
     },
-    ...GetStatusVirtualDom.getStatusVirtualDom(status),
+    ...GetStatusVirtualDom.getStatusVirtualDom(displayedStatus),
     ...GetRuntimeActivationEventVirtualDom.getRuntimeActivationEventVirtualDom(wasActivatedByEvent),
     ...GetActivationTimeVirtualDom.getActivationTimeVirtualDom(importTime, activationTime),
   ]

--- a/packages/extension-detail-view-worker/src/parts/GetStatusMessage/GetStatusMessage.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetStatusMessage/GetStatusMessage.ts
@@ -6,6 +6,8 @@ export const getStatusMessage = (statusType: number): string => {
       return 'activated'
     case RuntimeStatusType.Activating:
       return 'Activating'
+    case RuntimeStatusType.Disabled:
+      return 'Disabled'
     case RuntimeStatusType.Error:
       return 'error'
     case RuntimeStatusType.Importing:

--- a/packages/extension-detail-view-worker/src/parts/RuntimeStatusType/RuntimeStatusType.ts
+++ b/packages/extension-detail-view-worker/src/parts/RuntimeStatusType/RuntimeStatusType.ts
@@ -3,3 +3,4 @@ export const Importing = 1
 export const Activating = 2
 export const Activated = 3
 export const Error = 4
+export const Disabled = 5

--- a/packages/extension-detail-view-worker/test/FeatureRuntimeStatusVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/FeatureRuntimeStatusVirtualDom.test.ts
@@ -219,6 +219,23 @@ test('getRuntimeStatusVirtualDom should handle none status', () => {
   })
 })
 
+test('getRuntimeStatusVirtualDom should show disabled when the extension is disabled', () => {
+  const state: ExtensionDetailState = {
+    ...createDefaultState(),
+    disabled: true,
+    status: RuntimeStatusType.None,
+  }
+
+  const result = getRuntimeStatusVirtualDom(state)
+
+  expect(result).toHaveLength(8)
+  expect(result[7]).toEqual({
+    childCount: 0,
+    text: 'Disabled',
+    type: VirtualDomElements.Text,
+  })
+})
+
 test('getRuntimeStatusVirtualDom should format activation time correctly', () => {
   const state: ExtensionDetailState = {
     ...createDefaultState(),

--- a/packages/extension-detail-view-worker/test/GetStatusMessage.test.ts
+++ b/packages/extension-detail-view-worker/test/GetStatusMessage.test.ts
@@ -22,6 +22,11 @@ test('getStatusMessage should return "activated" for RuntimeStatusType.Activated
   expect(result).toBe('activated')
 })
 
+test('getStatusMessage should return "Disabled" for RuntimeStatusType.Disabled', () => {
+  const result = getStatusMessage(RuntimeStatusType.Disabled)
+  expect(result).toBe('Disabled')
+})
+
 test('getStatusMessage should return "error" for RuntimeStatusType.Error', () => {
   const result = getStatusMessage(RuntimeStatusType.Error)
   expect(result).toBe('error')


### PR DESCRIPTION
Show `Status: Disabled` in the Runtime Status feature whenever the extension is disabled. Includes focused coverage for the display status and rendered virtual DOM.