### PR TITLE
fix: adjust memory threshold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^17.5.0",
+        "@lvce-editor/eslint-config": "^17.6.0",
         "eslint": "^10.8.0",
         "knip": "^6.29.0",
         "prettier": "^3.9.6",
@@ -2963,9 +2963,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.5.0.tgz",
-      "integrity": "sha512-wjDaVd24PNVZdjbV8EcQYrbEWsKAJ9mak03EUIMTT6+tHVwlg9G1P2eDvqpxyMSmY3ywBKhAPigEjY2pwnCGUQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.6.0.tgz",
+      "integrity": "sha512-RsoXrwtogesQApVrpbZ7utR6qGHEetFFxJJu7CCrOXgve5sl6glWS5XRC/rAVUNgmmMRJVpj9ajuE0FPzzK92Q==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2978,15 +2978,15 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "17.5.0",
-        "@lvce-editor/eslint-plugin-e2e": "17.5.0",
-        "@lvce-editor/eslint-plugin-extension-json": "17.5.0",
-        "@lvce-editor/eslint-plugin-github-actions": "17.5.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "17.5.0",
-        "@lvce-editor/eslint-plugin-regex": "17.5.0",
-        "@lvce-editor/eslint-plugin-rpc": "17.5.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "17.5.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "17.5.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.6.0",
+        "@lvce-editor/eslint-plugin-e2e": "17.6.0",
+        "@lvce-editor/eslint-plugin-extension-json": "17.6.0",
+        "@lvce-editor/eslint-plugin-github-actions": "17.6.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.6.0",
+        "@lvce-editor/eslint-plugin-regex": "17.6.0",
+        "@lvce-editor/eslint-plugin-rpc": "17.6.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.6.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.6.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -3001,9 +3001,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.5.0.tgz",
-      "integrity": "sha512-wNemW3CGngT/bRzB2ldVWW5++V/Xq549Hkbf7ZCc00XGxJhupZKTAYL3qCQvpdT5OJTUFc58Z9ddg42OLVENiQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.6.0.tgz",
+      "integrity": "sha512-AmxCDywiOQAjq1HMnCLvVnxYuPwxrgopQ1o0/9VS8y2msNUGQ3/Mi1Mk+JJx+vE7wrCw83xZYbQmtBrdx40Ssg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3011,16 +3011,16 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.5.0.tgz",
-      "integrity": "sha512-xGWeOY+aitgaKgxCVeRSJfEWMLf39u5wnq0uA3ZnZKFWXEHpZO3CaJi+9rw7KgFK7TcqgpxsaAHTENYEoabJHQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.6.0.tgz",
+      "integrity": "sha512-Xxd7YBrU5TxlpUhc8YMO/IaEeCcLVKNUHMu6O+dvHHr5hF1orxSCfobTHchObDw+uPrcZWYFEk8o+2R1FJUEKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-extension-json": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-17.5.0.tgz",
-      "integrity": "sha512-F7qOAYW1LhFntc2f5Yn1QQqArqgVLi1tW6vRNzgWIptlrZTib0cGFG4jKOL7ZgB5uDl0mZWlZ9q1Q1T055eWhg==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-17.6.0.tgz",
+      "integrity": "sha512-tD/whQxE59mN2q3so3xFmvasqQteYCZX3fmbVuGzjQy74P6kFtI6ZWgkP0x3cHyP3JtB0e9Kin0dc1bPk1a9lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3028,9 +3028,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.5.0.tgz",
-      "integrity": "sha512-RhphHPbVQHqRu2yAZ/XnUdpP67BbPrIIrAvdkqSnitCVu65DDTTN1YVZMNdNv8cYue8V3V8eUMIf8WaNFBdJEQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.6.0.tgz",
+      "integrity": "sha512-GAoDHossq4mUrznh9BrAuAONPQMZyN9MND/+eXdZpnRLrn7Ng8KSJKl0Vs8c4a+peJ9uIDSae71lp5Q5t7251w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3039,9 +3039,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.5.0.tgz",
-      "integrity": "sha512-mYcLlKt8Y2wKlM13xFXKaYDvKDOj/O5nnfj51oW7UTItROxtlD848eaXcxpLrH5iLTW5wC3G3Oz9ftwoGmqq7A==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.6.0.tgz",
+      "integrity": "sha512-gTSF7iBiCcePmQegfaKAwHE5DA5LBc+yFOOKqA9bWQzKXf+9FdBZ2O6HikW1ms+lpbtG+SIYST5SBu710I1OrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3049,23 +3049,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.5.0.tgz",
-      "integrity": "sha512-PER04Hz35vvDFWXPK9wkSyAXB/H5aGGPE6i8nesbmGUP43fqT+7f9Kf5wzRUbUOdZ8HuFcnVQZALMbaEe1NcSg==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.6.0.tgz",
+      "integrity": "sha512-l7lsqZtQpuabIaw3FEhYCfb8dDwZ0BMCx5jj9ZG03ST5KceOL5WB2DGXGcflRvQKbyHPqngQH88r/bAMvbR2+Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.5.0.tgz",
-      "integrity": "sha512-7dfk74/7pFDK2fWnDK1M8OP46ehlMiK2TlOZYvsg3kU0J4dC0m7emnwvWKCgzyd/rNVPsTyqcz8PSM3U+4Lf4Q==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.6.0.tgz",
+      "integrity": "sha512-Y+ny8qJUBU2y75JCgxG6Rd+WZ9G1M6+bu7tRGgRSDLxLrkfkk1mIAT3i8XnT+qs9/E6+S4+AiGR3ulPU1OsKOg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.5.0.tgz",
-      "integrity": "sha512-505lmJeM12Bq5eTZ5FMjB7qmbSu0Xi8bjVCbBSjyMNAVhCAiEUfuWXq0TeiJFeT40GzF88On0GPYHxS+dviWmQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.6.0.tgz",
+      "integrity": "sha512-c/W6eplqZKJjKtkpKNF3vKttJImCEvVfOHgOgAW2yDzpC51qmpfwjPCwn7UrYhr58q/lKt7ZfTSAazhoP+T9cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3073,9 +3073,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.5.0.tgz",
-      "integrity": "sha512-sGiPawCOnR4E/8Bb+NTLlPpmvYS/t2vYrPwoG9/KVUq6gRnj3M34pQw2vsxP9A+PYig5LeL9TX5Wjj//DYVpXA==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.6.0.tgz",
+      "integrity": "sha512-Y3QGtPg62OlfVRtojbKHuv+1iuI9TwTNW9RFjCpvuVP+qcm1tF3CfqKngAZATkvYsQfvqXX4J8GXUdm80oyJ2g==",
       "dev": true,
       "license": "MIT"
     },
@@ -3886,9 +3886,9 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.43.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.43.0.tgz",
-      "integrity": "sha512-STUNoKvOO9D90p2sk3PXJKwVwEGwArBPB33pCImfBg6HrTP2Q/OPZMzi4HXwseNfusOO6xPlaiXKEND1fgwlOw==",
+      "version": "9.44.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.44.0.tgz",
+      "integrity": "sha512-bAs8KYfihThkh0LMlzPI1rQ+g39NNJwlrfWHD+/VfIf6K/21nnRxd7FRjHddlv/zhpJ9DtBRcpglZ7u7KJNBvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16447,7 +16447,7 @@
         "@lvce-editor/constants": "^5.20.0",
         "@lvce-editor/i18n": "^2.5.0",
         "@lvce-editor/rpc": "^6.10.0",
-        "@lvce-editor/rpc-registry": "^9.43.0",
+        "@lvce-editor/rpc-registry": "^9.44.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
         "@lvce-editor/virtual-dom-worker": "^11.8.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "printWidth": 150
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^17.5.0",
+    "@lvce-editor/eslint-config": "^17.6.0",
     "eslint": "^10.8.0",
     "knip": "^6.29.0",
     "prettier": "^3.9.6",

--- a/packages/extension-detail-view-worker/src/parts/GetChangelogVirtualDom/GetChangelogVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetChangelogVirtualDom/GetChangelogVirtualDom.ts
@@ -3,16 +3,15 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 
+const changelogNode: VirtualDomNode = {
+  childCount: 1,
+  className: MergeClassNames.mergeClassNames(ClassNames.ExtensionDetailPanel, ClassNames.Changelog),
+  role: AriaRoles.Panel,
+  type: VirtualDomElements.Div,
+}
+
 export const getChangelogVirtualDom = (changelogDom: readonly VirtualDomNode[]): readonly VirtualDomNode[] => {
   // const notImplemented = ExtensionDetailStrings.notImplemented()
   // TODO set tabpanel role
-  return [
-    {
-      childCount: 1,
-      className: MergeClassNames.mergeClassNames(ClassNames.ExtensionDetailPanel, ClassNames.Changelog),
-      role: AriaRoles.Panel,
-      type: VirtualDomElements.Div,
-    },
-    ...changelogDom,
-  ]
+  return [changelogNode, ...changelogDom]
 }

--- a/packages/extension-detail-view-worker/src/parts/GetExtensionDetailErrorVirtualDom/GetExtensionDetailErrorVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetExtensionDetailErrorVirtualDom/GetExtensionDetailErrorVirtualDom.ts
@@ -3,10 +3,22 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 
+const extensionDetailErrorNode: VirtualDomNode = {
+  childCount: 1,
+  className: MergeClassNames.mergeClassNames(ClassNames.Viewlet, ClassNames.ExtensionDetail, ClassNames.ExtensionDetailError),
+  type: VirtualDomElements.Div,
+}
+
 const extensionDetailErrorCardNode: VirtualDomNode = {
   childCount: 3,
   className: ClassNames.ExtensionDetailErrorCard,
   role: AriaRoles.Alert,
+  type: VirtualDomElements.Div,
+}
+
+const extensionDetailErrorIconNode: VirtualDomNode = {
+  childCount: 0,
+  className: MergeClassNames.mergeClassNames(ClassNames.MaskIcon, ClassNames.MaskIconWarning, ClassNames.ExtensionDetailErrorIcon),
   type: VirtualDomElements.Div,
 }
 
@@ -24,17 +36,9 @@ const extensionDetailErrorMessageNode: VirtualDomNode = {
 
 export const getExtensionDetailErrorVirtualDom = (title: string, message: string): readonly VirtualDomNode[] => {
   return [
-    {
-      childCount: 1,
-      className: MergeClassNames.mergeClassNames(ClassNames.Viewlet, ClassNames.ExtensionDetail, ClassNames.ExtensionDetailError),
-      type: VirtualDomElements.Div,
-    },
+    extensionDetailErrorNode,
     extensionDetailErrorCardNode,
-    {
-      childCount: 0,
-      className: MergeClassNames.mergeClassNames(ClassNames.MaskIcon, ClassNames.MaskIconWarning, ClassNames.ExtensionDetailErrorIcon),
-      type: VirtualDomElements.Div,
-    },
+    extensionDetailErrorIconNode,
     extensionDetailErrorTitleNode,
     text(title),
     extensionDetailErrorMessageNode,

--- a/packages/extension-detail-view-worker/src/parts/GetScrollToTopVirtualDom/GetScrollToTopVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetScrollToTopVirtualDom/GetScrollToTopVirtualDom.ts
@@ -5,6 +5,13 @@ import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEven
 import * as ExtensionDetailStrings from '../ExtensionDetailStrings/ExtensionDetailStrings.ts'
 import * as InputName from '../InputName/InputName.ts'
 
+const scrollToTopIconNode: VirtualDomNode = {
+  childCount: 0,
+  className: mergeClassNames(ClassNames.MaskIcon, ClassNames.MaskIconChevronUp),
+  role: AriaRoles.None,
+  type: VirtualDomElements.Div,
+}
+
 export const getScrollToTopVirtualDom = (scrollToTopButtonEnabled: boolean): readonly VirtualDomNode[] => {
   if (!scrollToTopButtonEnabled) {
     return []
@@ -18,11 +25,6 @@ export const getScrollToTopVirtualDom = (scrollToTopButtonEnabled: boolean): rea
       onClick: DomEventListenerFunctions.HandleClickScrollToTop,
       type: VirtualDomElements.Button,
     },
-    {
-      childCount: 0,
-      className: mergeClassNames(ClassNames.MaskIcon, ClassNames.MaskIconChevronUp),
-      role: AriaRoles.None,
-      type: VirtualDomElements.Div,
-    },
+    scrollToTopIconNode,
   ]
 }

--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 605_000
+export const threshold = 606_000
 
 export const instantiations = 16000
 


### PR DESCRIPTION
Raise the memory measurement threshold by 1 KB to account for the static virtual DOM nodes required by the updated ESLint configuration.