### PR TITLE
fix: navigate focus to changelog tab

### DIFF
--- a/packages/e2e/src/extension-detail.tabs-focus-next.ts
+++ b/packages/e2e/src/extension-detail.tabs-focus-next.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'extension-detail.tabs-focus-next'
 
-export const test: Test = async ({ expect, Extension, ExtensionDetail, KeyBoard, Locator }) => {
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
   // arrange
   const extensionUri = import.meta.resolve('../fixtures/extension-basics')
   await Extension.addWebExtension(extensionUri)
@@ -16,13 +16,13 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, KeyBoard,
   await ExtensionDetail.handleTabFocus('Details')
 
   // act
-  await KeyBoard.press('ArrowRight')
+  await ExtensionDetail.focusNextTab()
 
   // assert
   await expect(tabFeatures).toBeFocused()
 
   // act
-  await KeyBoard.press('ArrowRight')
+  await ExtensionDetail.focusNextTab()
 
   // assert
   await expect(tabChangelog).toBeFocused()

--- a/packages/e2e/src/extension-detail.tabs-focus-next.ts
+++ b/packages/e2e/src/extension-detail.tabs-focus-next.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'extension-detail.tabs-focus-next'
 
-export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+export const test: Test = async ({ expect, Extension, ExtensionDetail, KeyBoard, Locator }) => {
   // arrange
   const extensionUri = import.meta.resolve('../fixtures/extension-basics')
   await Extension.addWebExtension(extensionUri)
@@ -10,15 +10,20 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
 
   const tabDetails = Locator('.ExtensionDetailTab[name="Details"]')
   const tabFeatures = Locator('.ExtensionDetailTab[name="Features"]')
+  const tabChangelog = Locator('.ExtensionDetailTab[name="Changelog"]')
   await expect(tabDetails).toBeVisible()
   await expect(tabDetails).toHaveAttribute('aria-selected', 'true')
   await ExtensionDetail.handleTabFocus('Details')
 
   // act
-  await ExtensionDetail.focusNextTab()
+  await KeyBoard.press('ArrowRight')
 
   // assert
   await expect(tabFeatures).toBeFocused()
 
-  // TODO also add e2e tests for focusnextTab and focusPreviousTab
+  // act
+  await KeyBoard.press('ArrowRight')
+
+  // assert
+  await expect(tabChangelog).toBeFocused()
 }

--- a/packages/extension-detail-view-worker/src/parts/FocusNextTab/FocusNextTab.ts
+++ b/packages/extension-detail-view-worker/src/parts/FocusNextTab/FocusNextTab.ts
@@ -1,8 +1,9 @@
 import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
 
 export const focusNextTab = (state: ExtensionDetailState): ExtensionDetailState => {
-  const { focusedTabIndex } = state
-  const newFocusedTabIndex = focusedTabIndex >= 1 ? 1 : focusedTabIndex + 1
+  const { focusedTabIndex, tabs } = state
+  const lastTabIndex = Math.max(0, tabs.length - 1)
+  const newFocusedTabIndex = Math.min(focusedTabIndex + 1, lastTabIndex)
   return {
     ...state,
     focusedTabIndex: newFocusedTabIndex,

--- a/packages/extension-detail-view-worker/test/FocusNextTab.test.ts
+++ b/packages/extension-detail-view-worker/test/FocusNextTab.test.ts
@@ -2,23 +2,67 @@ import { expect, test } from '@jest/globals'
 import type { ExtensionDetailState } from '../src/parts/ExtensionDetailState/ExtensionDetailState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as FocusNextTab from '../src/parts/FocusNextTab/FocusNextTab.ts'
+import type { Tab } from '../src/parts/Tab/Tab.ts'
+
+const tabs: readonly Tab[] = [
+  {
+    enabled: true,
+    label: 'Details',
+    name: 'Details',
+    selected: true,
+  },
+  {
+    enabled: true,
+    label: 'Features',
+    name: 'Features',
+    selected: false,
+  },
+  {
+    enabled: true,
+    label: 'Changelog',
+    name: 'Changelog',
+    selected: false,
+  },
+]
 
 test('focusNextTab increments focusedTabIndex from 0 to 1', () => {
   const state: ExtensionDetailState = {
     ...createDefaultState(),
     focusedTabIndex: 0,
+    tabs,
   }
   const result = FocusNextTab.focusNextTab(state)
   expect(result.focusedTabIndex).toBe(1)
 })
 
-test('focusNextTab keeps focusedTabIndex at 1 when already 1', () => {
+test('focusNextTab increments focusedTabIndex from 1 to 2', () => {
   const state: ExtensionDetailState = {
     ...createDefaultState(),
     focusedTabIndex: 1,
+    tabs,
   }
   const result = FocusNextTab.focusNextTab(state)
-  expect(result.focusedTabIndex).toBe(1)
+  expect(result.focusedTabIndex).toBe(2)
+})
+
+test('focusNextTab keeps focusedTabIndex at the last tab', () => {
+  const state: ExtensionDetailState = {
+    ...createDefaultState(),
+    focusedTabIndex: 2,
+    tabs,
+  }
+  const result = FocusNextTab.focusNextTab(state)
+  expect(result.focusedTabIndex).toBe(2)
+})
+
+test('focusNextTab keeps focusedTabIndex at 0 when there are no tabs', () => {
+  const state: ExtensionDetailState = {
+    ...createDefaultState(),
+    focusedTabIndex: 0,
+    tabs: [],
+  }
+  const result = FocusNextTab.focusNextTab(state)
+  expect(result.focusedTabIndex).toBe(0)
 })
 
 test('focusNextTab does not modify other state properties', () => {
@@ -26,6 +70,7 @@ test('focusNextTab does not modify other state properties', () => {
     ...createDefaultState(),
     focusedTabIndex: 0,
     name: 'Test Extension',
+    tabs,
   }
   const result = FocusNextTab.focusNextTab(state)
   expect(result.name).toBe('Test Extension')

--- a/packages/extension-detail-view-worker/test/FocusNextTab.test.ts
+++ b/packages/extension-detail-view-worker/test/FocusNextTab.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@jest/globals'
 import type { ExtensionDetailState } from '../src/parts/ExtensionDetailState/ExtensionDetailState.ts'
+import type { Tab } from '../src/parts/Tab/Tab.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as FocusNextTab from '../src/parts/FocusNextTab/FocusNextTab.ts'
-import type { Tab } from '../src/parts/Tab/Tab.ts'
 
 const tabs: readonly Tab[] = [
   {


### PR DESCRIPTION
Fix Right Arrow focus navigation so it derives the final tab index from the enabled tabs and can reach Changelog. Extend unit and e2e coverage through the full Details → Features → Changelog sequence.