### PR TITLE
fix: update package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2944,9 +2944,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.23.0.tgz",
-      "integrity": "sha512-hjkqo7QLQl7pL2c+rH54q0/8dSpKDSfF6/3BvBAS2NsSpvtCnab3Ew4bhVyMJrw1c9RnwcC2pmy6iDPtPpz0IQ==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.24.0.tgz",
+      "integrity": "sha512-PfoXM8k5Na8kGwERyHRyCZfSq4AGYcjbvDJv+Y4zdCRsT9qvr5QNM7HCDkH4LU1RdM2nrmO8I1ufzNy8NtfZ6w==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
@@ -3886,14 +3886,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.44.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.44.0.tgz",
-      "integrity": "sha512-bAs8KYfihThkh0LMlzPI1rQ+g39NNJwlrfWHD+/VfIf6K/21nnRxd7FRjHddlv/zhpJ9DtBRcpglZ7u7KJNBvw==",
+      "version": "9.45.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.45.0.tgz",
+      "integrity": "sha512-ypYUPS9mBnTJDKfJ9P5ECdrsqHTEhjp6ikWLBLaDXnsNWbgmEmntTiEtlAQegwsPlBUblm69HGzESR4D5ot85g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.23.0",
+        "@lvce-editor/constants": "^5.24.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
@@ -16447,7 +16447,7 @@
         "@lvce-editor/constants": "^5.20.0",
         "@lvce-editor/i18n": "^2.5.0",
         "@lvce-editor/rpc": "^6.10.0",
-        "@lvce-editor/rpc-registry": "^9.44.0",
+        "@lvce-editor/rpc-registry": "^9.45.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
         "@lvce-editor/virtual-dom-worker": "^11.8.1",


### PR DESCRIPTION
Synchronizes the lockfile with the current workspace dependency versions so clean installs and the existing Knip lint gate run successfully.