### PR TITLE
fix: hide marketplace for builtin extensions

### DIFF
--- a/packages/extension-detail-view-worker/src/parts/HandleClickSetColorTheme/HandleClickSetColorTheme.ts
+++ b/packages/extension-detail-view-worker/src/parts/HandleClickSetColorTheme/HandleClickSetColorTheme.ts
@@ -2,6 +2,7 @@ import { DialogWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
 import { getColorThemeId, getColorThemeLabel } from '../GetColorThemeId/GetColorThemeId.ts'
 import { getExtensionDetailButtons } from '../GetExtensionDetailButtons/GetExtensionDetailButtons.ts'
+import { isBuiltinExtension } from '../IsBuiltinExtension/IsBuiltinExtension.ts'
 import * as SetColorTheme from '../SetColorTheme/SetColorTheme.ts'
 
 export const handleClickSetColorTheme = async (state: ExtensionDetailState): Promise<ExtensionDetailState> => {
@@ -12,7 +13,7 @@ export const handleClickSetColorTheme = async (state: ExtensionDetailState): Pro
     if (error) {
       await DialogWorker.invoke('ConfirmPrompt.prompt', `${error}`)
     }
-    const isBuiltin = extension?.isBuiltin || extension?.builtin || false
+    const isBuiltin = isBuiltinExtension(extension)
     const colorThemeLabel = getColorThemeLabel(extension) || ''
     const buttons = getExtensionDetailButtons(hasColorTheme, isBuiltin, disabled, colorThemeId, colorThemeLabel, colorThemeId)
     return {

--- a/packages/extension-detail-view-worker/src/parts/HandleColorThemeChanged/HandleColorThemeChanged.ts
+++ b/packages/extension-detail-view-worker/src/parts/HandleColorThemeChanged/HandleColorThemeChanged.ts
@@ -1,6 +1,7 @@
 import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
 import { getColorThemeId, getColorThemeLabel } from '../GetColorThemeId/GetColorThemeId.ts'
 import { getExtensionDetailButtons } from '../GetExtensionDetailButtons/GetExtensionDetailButtons.ts'
+import { isBuiltinExtension } from '../IsBuiltinExtension/IsBuiltinExtension.ts'
 
 export const handleColorThemeChanged = (state: ExtensionDetailState, colorThemeId: string): ExtensionDetailState => {
   const { currentColorThemeId, disabled, extension, hasColorTheme } = state
@@ -9,7 +10,7 @@ export const handleColorThemeChanged = (state: ExtensionDetailState, colorThemeI
   }
   const extensionColorThemeId = getColorThemeId(extension) || ''
   const extensionColorThemeLabel = getColorThemeLabel(extension) || ''
-  const isBuiltin = extension?.isBuiltin || extension?.builtin || false
+  const isBuiltin = isBuiltinExtension(extension)
   const buttons = getExtensionDetailButtons(hasColorTheme, isBuiltin, disabled, extensionColorThemeId, extensionColorThemeLabel, colorThemeId)
   return {
     ...state,

--- a/packages/extension-detail-view-worker/src/parts/IsBuiltinExtension/IsBuiltinExtension.ts
+++ b/packages/extension-detail-view-worker/src/parts/IsBuiltinExtension/IsBuiltinExtension.ts
@@ -1,0 +1,9 @@
+interface Extension {
+  readonly builtin?: boolean
+  readonly id?: string
+  readonly isBuiltin?: boolean
+}
+
+export const isBuiltinExtension = (extension: Extension | null | undefined): boolean => {
+  return Boolean(extension?.isBuiltin || extension?.builtin || extension?.id?.startsWith('builtin'))
+}

--- a/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
@@ -25,6 +25,7 @@ import * as GetTabs from '../GetTabs/GetTabs.ts'
 import * as GetViewletSize from '../GetViewletSize/GetViewletSize.ts'
 import * as InputName from '../InputName/InputName.ts'
 import * as InputSource from '../InputSource/InputSource.ts'
+import { isBuiltinExtension } from '../IsBuiltinExtension/IsBuiltinExtension.ts'
 import * as LoadHeaderContent from '../LoadHeaderContent/LoadHeaderContent.ts'
 import * as GetExtensionReadme from '../LoadReadmeContent/LoadReadmeContent.ts'
 import { loadSideBarContent } from '../LoadSideBarContent/LoadSideBarContent.ts'
@@ -96,7 +97,7 @@ const loadContentInternal = async (
   const detailsVirtualDom = await getMarkdownVirtualDom(readmeHtml, {
     scrollToTopEnabled: true,
   })
-  const isBuiltin = extension?.isBuiltin || extension?.builtin || false
+  const isBuiltin = isBuiltinExtension(extension)
   const disabled = extension?.disabled
   const extensionColorThemeId = getColorThemeId(extension) || ''
   const extensionColorThemeLabel = getColorThemeLabel(extension) || ''

--- a/packages/extension-detail-view-worker/src/parts/LoadHeaderContent/LoadHeaderContent.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadHeaderContent/LoadHeaderContent.ts
@@ -3,6 +3,7 @@ import type { HeaderData } from '../HeaderData/HeaderData.ts'
 import * as ExtensionDisplay from '../ExtensionDisplay/ExtensionDisplay.ts'
 import * as GetBadge from '../GetBadge/GetBadge.ts'
 import * as HasColorThemes from '../HasColorThemes/HasColorThemes.ts'
+import { isBuiltinExtension } from '../IsBuiltinExtension/IsBuiltinExtension.ts'
 
 export const loadHeaderContent = (state: ExtensionDetailState, platform: number, extension: any): HeaderData => {
   const { assetDir, builtinExtensionsBadgeEnabled } = state
@@ -13,7 +14,7 @@ export const loadHeaderContent = (state: ExtensionDetailState, platform: number,
   const extensionId = extension?.id || 'n/a'
   const extensionVersion = extension?.version || 'n/a'
   const hasColorTheme = HasColorThemes.hasColorThemes(extension)
-  const isBuiltin = extension?.isBuiltin || extension?.builtin || false
+  const isBuiltin = isBuiltinExtension(extension)
   const badge = GetBadge.getBadge(isBuiltin, builtinExtensionsBadgeEnabled)
   const downloadCount = isBuiltin ? 'n/a' : ExtensionDisplay.getDownloadCount(extension)
   const rating = isBuiltin ? 'n/a' : ExtensionDisplay.getRating(extension)

--- a/packages/extension-detail-view-worker/src/parts/UpdateExtensionStatus/UpdateExtensionStatus.ts
+++ b/packages/extension-detail-view-worker/src/parts/UpdateExtensionStatus/UpdateExtensionStatus.ts
@@ -3,6 +3,7 @@ import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDeta
 import * as ExtensionManagement from '../ExtensionManagement/ExtensionManagement.ts'
 import { getColorThemeId, getColorThemeLabel } from '../GetColorThemeId/GetColorThemeId.ts'
 import { getExtensionDetailButtons } from '../GetExtensionDetailButtons/GetExtensionDetailButtons.ts'
+import { isBuiltinExtension } from '../IsBuiltinExtension/IsBuiltinExtension.ts'
 
 export interface UpdateFunction {
   (extensionId: string, platform: number): Promise<any>
@@ -18,7 +19,7 @@ export const updateExtensionStatus = async (state: ExtensionDetailState, updateF
   const disabled = extension?.disabled
   const extensionColorThemeId = getColorThemeId(extension) || ''
   const extensionColorThemeLabel = getColorThemeLabel(extension) || ''
-  const isBuiltin = extension?.isBuiltin || extension?.builtin || false
+  const isBuiltin = isBuiltinExtension(extension)
   const buttons = getExtensionDetailButtons(hasColorTheme, isBuiltin, disabled, extensionColorThemeId, extensionColorThemeLabel, currentColorThemeId)
   return {
     ...state,

--- a/packages/extension-detail-view-worker/test/IsBuiltinExtension.test.ts
+++ b/packages/extension-detail-view-worker/test/IsBuiltinExtension.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@jest/globals'
+import { isBuiltinExtension } from '../src/parts/IsBuiltinExtension/IsBuiltinExtension.ts'
+
+test('returns true when the extension id starts with builtin', () => {
+  expect(isBuiltinExtension({ id: 'builtin.language-basics-java' })).toBe(true)
+})
+
+test('returns true when builtin metadata is set', () => {
+  expect(isBuiltinExtension({ builtin: true, id: 'test-extension' })).toBe(true)
+  expect(isBuiltinExtension({ id: 'test-extension', isBuiltin: true })).toBe(true)
+})
+
+test('returns false for a marketplace extension', () => {
+  expect(isBuiltinExtension({ id: 'publisher.extension' })).toBe(false)
+})
+
+test('returns false when the extension is missing', () => {
+  expect(isBuiltinExtension(undefined)).toBe(false)
+})

--- a/packages/extension-detail-view-worker/test/LoadContent.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadContent.test.ts
@@ -174,9 +174,8 @@ test('loadContent - unexpected load error', async () => {
 
 test('loadContent - with builtin extension', async () => {
   const mockExtension: any = {
-    builtin: true,
     description: 'A builtin extension',
-    id: 'builtin-extension',
+    id: 'builtin.language-basics-java',
     name: 'Builtin Extension',
     path: '/test/path',
     version: '1.0.0',
@@ -223,15 +222,16 @@ test('loadContent - with builtin extension', async () => {
 
   const state: ExtensionDetailState = {
     ...createDefaultState(),
-    uri: 'extension-detail://builtin-extension',
+    uri: 'extension-detail://builtin.language-basics-java',
   }
 
   const result: ExtensionDetailState = await LoadContent.loadContent(state, 1, {})
 
   expect(result.extension).toEqual(mockExtension)
+  expect(result.badge).toBe('builtin')
   expect(result.marketplaceEntries).toEqual([])
   expect(mockRendererRpc.invocations).toEqual([
-    ['ExtensionManagement.getExtension', 'builtin-extension'],
+    ['ExtensionManagement.getExtension', 'builtin.language-basics-java'],
     ['Preferences.get', 'workbench.colorTheme'],
     ['Preferences.getAll'],
     ['Preferences.get', 'workbnech.colorTheme'],


### PR DESCRIPTION
Marks extensions whose IDs start with builtin as builtin extensions. This keeps builtin badges and actions consistent and removes the Marketplace section from their detail view.