### PR TITLE
Fix extension details for languages without file extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3864,9 +3864,9 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.46.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.46.1.tgz",
-      "integrity": "sha512-PvahetTO/UKlbCi54fo/5xJe+0ExBLEKeE9L/B8Y1vXyHJ9nirX/cvrZkO4vl79Fdt6OtPl58zgXAfabmGovDA==",
+      "version": "9.47.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.47.0.tgz",
+      "integrity": "sha512-EmtSPKK3XMt49CeyzLdSv+Ey4umTRIOOS64Inn/mJxCcmRe+bUi4+ik98PAf9Z+AfLiEV3d/Yjgs2IvBzvKJeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16408,7 +16408,7 @@
         "@lvce-editor/constants": "^5.20.0",
         "@lvce-editor/i18n": "^2.5.0",
         "@lvce-editor/rpc": "^6.10.0",
-        "@lvce-editor/rpc-registry": "^9.46.1",
+        "@lvce-editor/rpc-registry": "^9.47.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
         "@lvce-editor/virtual-dom-worker": "^11.8.1",

--- a/packages/e2e/fixtures/extension-programming-languages/extension.json
+++ b/packages/e2e/fixtures/extension-programming-languages/extension.json
@@ -8,6 +8,11 @@
       "extensions": [".css"],
       "tokenize": "src/tokenizeCss.js",
       "configuration": "languageConfiguration.json"
+    },
+    {
+      "id": "nvmrc",
+      "fileNames": [".nvmrc", ".node-version"],
+      "tokenize": "src/tokenizeNvmrc.js"
     }
   ]
 }

--- a/packages/e2e/src/extension-detail.feature-programming-languages-table-structure.ts
+++ b/packages/e2e/src/extension-detail.feature-programming-languages-table-structure.ts
@@ -12,9 +12,9 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
 
   const table = Locator('.FeatureContent > table.Table')
   await expect(table.locator('thead th.TableHeading')).toHaveCount(5)
-  await expect(table.locator('tbody tr')).toHaveCount(1)
+  await expect(table.locator('tbody tr')).toHaveCount(2)
   const cells = table.locator('tbody td.TableCell')
   const extension = cells.nth(2).locator('code')
-  await expect(cells).toHaveCount(5)
+  await expect(cells).toHaveCount(10)
   await expect(extension).toHaveText('.css')
 }

--- a/packages/e2e/src/extension-detail.feature-programming-languages.ts
+++ b/packages/e2e/src/extension-detail.feature-programming-languages.ts
@@ -40,4 +40,8 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await expect(cell4).toHaveText('yes')
   const cell5 = tableCells.nth(4)
   await expect(cell5).toHaveText('no')
+  const cell6 = tableCells.nth(5)
+  await expect(cell6).toHaveText('nvmrc')
+  const cell8 = tableCells.nth(7)
+  await expect(cell8).toHaveText('')
 }

--- a/packages/extension-detail-view-worker/src/parts/GetProgrammingLanguageTableEntry/GetProgrammingLanguageTableEntry.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetProgrammingLanguageTableEntry/GetProgrammingLanguageTableEntry.ts
@@ -2,7 +2,7 @@ import type { Row } from '../Row/Row.ts'
 import * as TableCellType from '../TableCellType/TableCellType.ts'
 
 export const getProgrammingLanguageTableEntry = (programmingLanguage: any): Row => {
-  const { configuration, extensions, id } = programmingLanguage
+  const { configuration, extensions = [], id } = programmingLanguage
   const name = '' // TODO
   const snippets = '' // TODO
   return [

--- a/packages/extension-detail-view-worker/test/GetProgrammingLanguageTableEntry.test.ts
+++ b/packages/extension-detail-view-worker/test/GetProgrammingLanguageTableEntry.test.ts
@@ -99,6 +99,20 @@ test('getProgrammingLanguageTableEntry with empty extensions array', () => {
   })
 })
 
+test('getProgrammingLanguageTableEntry without extensions', () => {
+  const programmingLanguage = {
+    fileNames: ['.nvmrc', '.node-version'],
+    id: 'nvmrc',
+  }
+  const result = getProgrammingLanguageTableEntry(programmingLanguage)
+
+  expect(result[2]).toEqual({
+    listItems: [],
+    type: TableCellType.CodeList,
+    value: '',
+  })
+})
+
 test('getProgrammingLanguageTableEntry with single extension', () => {
   const programmingLanguage = {
     configuration: {},


### PR DESCRIPTION
Normalizes missing language extension arrays so filename-only contributions, such as language-basics-nvmrc, render without crashing. Adds focused worker and browser regression coverage.