### PR TITLE
Fix empty extension detail table cells

### DIFF
--- a/packages/e2e/src/extension-detail.feature-json-validation-schema-link-empty-string.ts
+++ b/packages/e2e/src/extension-detail.feature-json-validation-schema-link-empty-string.ts
@@ -19,7 +19,7 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   const commandsTable = Locator('.FeatureContent .Table')
   await expect(commandsTable).toBeVisible()
   const cell2 = commandsTable.locator('tbody td').nth(1)
-  await expect(cell2).toHaveText('')
+  await expect(cell2).toHaveText('-')
   const link = cell2.locator('a')
   await expect(link).toBeHidden()
 }

--- a/packages/e2e/src/extension-detail.feature-programming-languages.ts
+++ b/packages/e2e/src/extension-detail.feature-programming-languages.ts
@@ -33,7 +33,7 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   const cell1 = tableCells.nth(0)
   await expect(cell1).toHaveText('css')
   const cell2 = tableCells.nth(1)
-  await expect(cell2).toHaveText('')
+  await expect(cell2).toHaveText('-')
   const cell3 = tableCells.nth(2)
   await expect(cell3).toHaveText('.css')
   const cell4 = tableCells.nth(3)
@@ -42,6 +42,8 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await expect(cell5).toHaveText('no')
   const cell6 = tableCells.nth(5)
   await expect(cell6).toHaveText('nvmrc')
+  const cell7 = tableCells.nth(6)
+  await expect(cell7).toHaveText('-')
   const cell8 = tableCells.nth(7)
-  await expect(cell8).toHaveText('')
+  await expect(cell8).toHaveText('-')
 }

--- a/packages/extension-detail-view-worker/src/parts/GetCellVirtualDom/GetCellVirtualDom.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetCellVirtualDom/GetCellVirtualDom.ts
@@ -1,9 +1,24 @@
 import type { Cell } from '../Cell/Cell.ts'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as GetCellRenderer from '../GetCellRenderer/GetCellRenderer.ts'
+import * as GetCellTextVirtualDom from '../GetCellTextVirtualDom/GetCellTextVirtualDom.ts'
+import * as TableCellType from '../TableCellType/TableCellType.ts'
+
+const isEmptyCell = (entry: Cell): boolean => {
+  if (entry.type === TableCellType.CheckMark) {
+    return false
+  }
+  if (entry.type === TableCellType.CodeList) {
+    return entry.listItems.length === 0
+  }
+  return !entry.value || (Array.isArray(entry.value) && entry.value.length === 0)
+}
 
 export const getCellVirtualDom = (entry: Cell): readonly VirtualDomNode[] => {
   const { type, value, ...props } = entry
   const fn = GetCellRenderer.getCellRenderer(type)
+  if (isEmptyCell(entry)) {
+    return GetCellTextVirtualDom.getCellTextVirtualDom('-', props)
+  }
   return fn(value, props)
 }

--- a/packages/extension-detail-view-worker/test/GetCellVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetCellVirtualDom.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@jest/globals'
+import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import * as ClassNames from '../src/parts/ClassNames/ClassNames.ts'
+import * as GetCellVirtualDom from '../src/parts/GetCellVirtualDom/GetCellVirtualDom.ts'
+import * as TableCellType from '../src/parts/TableCellType/TableCellType.ts'
+import { text } from '../src/parts/VirtualDomHelpers/VirtualDomHelpers.ts'
+
+const emptyCellDom = [
+  {
+    childCount: 1,
+    className: ClassNames.TableCell,
+    type: VirtualDomElements.Td,
+  },
+  text('-'),
+]
+
+test('renders a placeholder for an empty text cell', () => {
+  expect(GetCellVirtualDom.getCellVirtualDom({ type: TableCellType.Text, value: '' })).toEqual(emptyCellDom)
+})
+
+test('renders a placeholder for an undefined text cell', () => {
+  expect(GetCellVirtualDom.getCellVirtualDom({ type: TableCellType.Text, value: undefined as any })).toEqual(emptyCellDom)
+})
+
+test('renders a placeholder for an empty code list cell', () => {
+  expect(GetCellVirtualDom.getCellVirtualDom({ listItems: [], type: TableCellType.CodeList, value: '' })).toEqual(emptyCellDom)
+})
+
+test('renders check mark cells normally', () => {
+  expect(GetCellVirtualDom.getCellVirtualDom({ checked: false, type: TableCellType.CheckMark, value: '' })).toEqual([
+    {
+      childCount: 1,
+      className: ClassNames.TableCell,
+      type: VirtualDomElements.Td,
+    },
+    text('no'),
+  ])
+})


### PR DESCRIPTION
Render a dash placeholder in extension detail table cells that have no content. Covers empty text values and empty code lists in the programming languages feature.