### PR TITLE
Fix initially selected changelog content

### DIFF
--- a/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/extension-detail-view-worker/src/parts/LoadContent/LoadContent.ts
@@ -35,6 +35,7 @@ import * as Path from '../Path/Path.ts'
 import * as RenderMarkdown from '../RenderMarkdown/RenderMarkdown.ts'
 import * as RestoreState from '../RestoreState/RestoreState.ts'
 import * as SelectFeature from '../SelectFeature/SelectFeature.ts'
+import * as SelectTabChangelog from '../SelectTabChangelog/SelectTabChangelog.ts'
 
 const isEnabled = (tab: Tab): boolean => {
   return tab.enabled
@@ -179,6 +180,9 @@ const loadContentInternal = async (
   }
   if (selectedTab === InputName.Features) {
     return SelectFeature.selectFeature(loadedState, actualSelectedFeature)
+  }
+  if (selectedTab === InputName.Changelog) {
+    return SelectTabChangelog.selectTabChangelog(loadedState)
   }
   return loadedState
 }

--- a/packages/extension-detail-view-worker/test/LoadContent.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadContent.test.ts
@@ -432,6 +432,78 @@ test('loadContent - loads the selected feature details when restoring the featur
   expect(mockMarkdownRpc.invocations.length).toBeGreaterThan(0)
 })
 
+test('loadContent - loads changelog content when restoring the changelog tab', async () => {
+  const mockExtension: any = {
+    builtin: false,
+    description: 'A test extension',
+    id: 'test-extension',
+    name: 'Test Extension',
+    path: '/test/path',
+    uri: '/test/uri',
+    version: '1.0.0',
+  }
+  const changelogContent = '# Changelog\n\n## Version 1.0.0'
+  const changelogDom = [{ childCount: 1, type: 1 }]
+
+  using mockRendererRpc = RendererWorker.registerMockRpc({
+    'ExtensionManagement.getExtension': () => {
+      return mockExtension
+    },
+    'Layout.getApplicationName': () => {
+      return 'test-app'
+    },
+    'Layout.getCommit': () => {
+      return 'test-commit'
+    },
+    'Preferences.get': () => {
+      return true
+    },
+  })
+
+  using mockFileSystemRpc = FileSystemWorker.registerMockRpc({
+    'FileSystem.exists': () => {
+      return true
+    },
+    'FileSystem.getFolderSize': () => {
+      return 1024
+    },
+    'FileSystem.readFile': (uri: string) => {
+      return uri.endsWith('/CHANGELOG.md') ? changelogContent : '# Test README Content'
+    },
+  })
+
+  using mockMarkdownRpc = MarkdownWorker.registerMockRpc({
+    'Markdown.getMarkdownDom': () => {
+      return changelogDom
+    },
+    'Markdown.getVirtualDom': () => {
+      return changelogDom
+    },
+    'Markdown.render': (markdown: string) => {
+      return markdown === changelogContent ? '<h1>Changelog</h1><h2>Version 1.0.0</h2>' : '<h1>Test README Content</h1>'
+    },
+  })
+
+  const state: ExtensionDetailState = {
+    ...createDefaultState(),
+    uri: 'extension-detail://test-extension',
+  }
+  const savedState = {
+    selectedTab: InputName.Changelog,
+  }
+
+  const result = await LoadContent.loadContent(state, 1, savedState)
+
+  expect(result.selectedTab).toBe(InputName.Changelog)
+  expect(result.changelogVirtualDom.length).toBeGreaterThan(0)
+  expect(mockFileSystemRpc.invocations).toContainEqual(['FileSystem.readFile', 'https://lvce-editor.github.io/test/uri/CHANGELOG.md'])
+  expect(mockMarkdownRpc.invocations).toContainEqual([
+    'Markdown.render',
+    changelogContent,
+    expect.objectContaining({ baseUrl: '/test/path', locationProtocol: 'https:' }),
+  ])
+})
+
 test('loadContent - with different platform', async () => {
   const mockExtension: any = {
     builtin: false,

--- a/packages/extension-detail-view-worker/test/LoadContent.test.ts
+++ b/packages/extension-detail-view-worker/test/LoadContent.test.ts
@@ -502,6 +502,7 @@ test('loadContent - loads changelog content when restoring the changelog tab', a
     changelogContent,
     expect.objectContaining({ baseUrl: '/test/path', locationProtocol: 'https:' }),
   ])
+  expect(mockRendererRpc.invocations.length).toBeGreaterThan(0)
 })
 
 test('loadContent - with different platform', async () => {


### PR DESCRIPTION
Fixes extension details restored with the Changelog tab selected so the changelog content is loaded immediately instead of appearing blank until another tab is opened.