### PR TITLE
fix: load extension details on web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2888,14 +2888,25 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@lvce-editor/assert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
       "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
       "license": "MIT"
+    },
+    "node_modules/@lvce-editor/auth-process": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.10.0.tgz",
+      "integrity": "sha512-GlyU+4vJG88eSRsp9rjcj/ZDGRKR8oYKFAKB7pKA8ovSz9OlS14ddnqlaS5uZ6zpD2u5D6iS2eO78AeSvAaiBg==",
+      "license": "MIT",
+      "bin": {
+        "auth-process": "bin/oauthProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
     },
     "node_modules/@lvce-editor/command": {
       "version": "2.0.0",
@@ -2910,9 +2921,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.15.0.tgz",
-      "integrity": "sha512-Z9B7YS7KAzia8lI1XR4Grx5Rl+OX2ow5PuAePLh1n4gx5BB40VeJX7Jj9scOZRclUQQmhCkH6MQt28jhIXNQ4A==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.10.0.tgz",
+      "integrity": "sha512-mEKsVl6i/Qd/YQuFvzr6806pg6YIq0vo9AQ1v42U7ir+7sD3y3fvUcEL7yyOrC2+CimeoByj8BTEHHMFJNuB2w==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -3055,29 +3066,146 @@
       "link": true
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.97.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.97.25.tgz",
-      "integrity": "sha512-qwo/5cW0eWbrVvy4+VFOS46XWNdx5DjEOV74Nn5J3A1rubwsiHRvVx4MpTXoWlFUAwJMDd4enmplIfDlrD9DHA==",
+      "version": "0.94.4",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.94.4.tgz",
+      "integrity": "sha512-b/x3pN7jpEp4q1bNQDDduQ+tleSmPeWG1YuSLIrcPYkZYSht+W0pHCU1T6cZzxLTThRFJ0fJRlhIl5/c9/FMLQ==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.9.0",
-        "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/rpc": "^6.16.0",
-        "@lvce-editor/verror": "^1.7.0"
+        "@lvce-editor/assert": "^1.7.0",
+        "@lvce-editor/rpc": "^6.8.0",
+        "@lvce-editor/verror": "^1.7.0",
+        "execa": "^9.6.1",
+        "got": "^15.1.0",
+        "minimist": "^1.2.8"
       },
       "engines": {
         "node": ">=24"
       }
     },
+    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.11.0.tgz",
-      "integrity": "sha512-g1rGvTIBggaG9emayBczibKs+eOJgkOtbgp3TidDpuSwaX7uJotLBCGJNQyu6QhPPLskmkz1d5L4R+7bOzO/oA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.5.1.tgz",
+      "integrity": "sha512-kmVihRCa4LpcgwC4KN+jtdYuAAn+2UWfjtBaAZmuDLVqElQnn+lExWvjQoD3U2dOble9WU9/Y8uX5ejRI4mJEQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "trash": "^10.1.1",
-        "ws": "^8.21.1"
+        "ws": "^8.21.0"
       },
       "bin": {
         "file-system-process": "bin/fileSystemProcess.js"
@@ -3087,9 +3215,9 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.12.0.tgz",
-      "integrity": "sha512-3nLW4QWoH9eLpQ2bcKrawNxH7q2aLbdH0+E19kmlukOTM+HWmIj9dnJKr3zPiOKOnUjE/S0bZwB1gL+2Arbd4g==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.6.3.tgz",
+      "integrity": "sha512-Kjxgiv4HfJ3tDVicgfjzpBQLxZtUs4N5AjcSui3sl9pxvoW6kYhv13BakIaBXlvxpOsHSsbKITRwkCtmu0cJ+g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3297,6 +3425,19 @@
         "open": "^10.1.2"
       }
     },
+    "node_modules/@lvce-editor/network-process/node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@lvce-editor/network-process/node_modules/execa": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -3381,6 +3522,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/@lvce-editor/network-process/node_modules/got": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
+      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sindresorhus/is": "^7.0.1",
+        "byte-counter": "^0.1.0",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^13.0.12",
+        "decompress-response": "^10.0.0",
+        "form-data-encoder": "^4.0.2",
+        "http2-wrapper": "^2.2.1",
+        "keyv": "^5.5.3",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^4.0.1",
+        "responselike": "^4.0.2",
+        "type-fest": "^4.26.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
     "node_modules/@lvce-editor/network-process/node_modules/human-signals": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
@@ -3406,6 +3574,29 @@
       "optional": true,
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3554,6 +3745,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@lvce-editor/network-process/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@lvce-editor/network-process/node_modules/wsl-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
@@ -3607,9 +3811,9 @@
       }
     },
     "node_modules/@lvce-editor/process-explorer": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.14.0.tgz",
-      "integrity": "sha512-PfJKcKPyqoxOhMJLXFMSTz9mrzWvK+rYgo3lZQQFBdEEwuC/m8laV4eppvKMucWsLJPfTCKFc1gtMqpXfSLUVw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.12.0.tgz",
+      "integrity": "sha512-BrGgUrk7BwWS5hm6KczqksVD9bIYVMjaQh2njxt3ZDn2dURXAcNtyfWJlnXelAw7ccUWJXNaS0GlUZxPVG7aXA==",
       "license": "MIT",
       "bin": {
         "process-explorer": "bin/processExplorer.js"
@@ -3622,14 +3826,11 @@
       }
     },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.7.0.tgz",
-      "integrity": "sha512-wx/4AUOJJfPVBlgueNrF/lFODN2575KIwfE5vHCl26jFr8qWJHvmypv/91eoq4whA5wGzH+tjEvO4t4FT8GSrg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.3.0.tgz",
+      "integrity": "sha512-g2hTRb7lSc3uZaLq54dthlNG9ANG6eyJYPMih/WMqq+8GSoRblhbZZhsUpJdpaTb7hnwcsJ3y0LK5X8IKm2tDQ==",
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "@lvce-editor/command": "^2.0.0"
-      },
       "bin": {
         "pty-host": "bin/ptyHost.js"
       },
@@ -3667,6 +3868,7 @@
       "version": "9.47.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.47.0.tgz",
       "integrity": "sha512-EmtSPKK3XMt49CeyzLdSv+Ey4umTRIOOS64Inn/mJxCcmRe+bUi4+ik98PAf9Z+AfLiEV3d/Yjgs2IvBzvKJeg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -3675,14 +3877,15 @@
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.1.tgz",
-      "integrity": "sha512-XQfgR8TK0NN5tnkPnu5mlf7oEe66PwxbfJCCxjFD+XbXRtmYJZpUPitAjkZE5p1awl7RrQMJFUin8uC3mfulig==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.1.0.tgz",
+      "integrity": "sha512-GlRDR+Mgy/ln2+J1UiYeAvTxkamnVAOXfsJwp6N4SpQllh1+3zKUjDduUIABakoIIP13Fk4InF0b9VQI/wvrew==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
+        "@lvce-editor/constants": "^5.14.0",
         "execa": "^9.6.1",
-        "ws": "^8.21.1"
+        "ws": "^8.21.0"
       },
       "bin": {
         "search-process": "bin/searchProcess.js"
@@ -3691,7 +3894,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/ripgrep": "^5.2.0"
+        "@lvce-editor/ripgrep": "^5.1.0"
       }
     },
     "node_modules/@lvce-editor/search-process/node_modules/execa": {
@@ -3818,13 +4021,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.97.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.97.25.tgz",
-      "integrity": "sha512-vA+GU1J8yW929cF7FdgxJBtIMMA2akfJ0ypf5pxOO08wRptZJhrGeCIQY5DBf5hVzKFtexUJQGfzVSje0tBgzw==",
+      "version": "0.94.4",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.94.4.tgz",
+      "integrity": "sha512-yobFM5MLahgdIUEnZZbAl28W1zDAgASRbm8dh+B/9XFlB5clZW3LjQa2RU++WPQ9NME+/KSIo2S0EcVwSmt2QQ==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.97.25",
-        "@lvce-editor/static-server": "0.97.25"
+        "@lvce-editor/shared-process": "0.94.4",
+        "@lvce-editor/static-server": "0.94.4"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3834,47 +4037,85 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.97.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.97.25.tgz",
-      "integrity": "sha512-l5E+I6e1iLObCEzXk41AUjiu26KBnYOwFrbGu5Ba+CiZ9o5OVyzEdUBu7g/t2BvfTSZx6UHPwzV0bQ0PF05vlw==",
+      "version": "0.94.4",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.94.4.tgz",
+      "integrity": "sha512-cMi/BuE61/YkBkZ3p7cVTDi9JT85l/qisS63L+/dzGLav7vsw4TTtB3+sKW8MrMGwQH5HDtbMQ26ARnThyhDIw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.97.25",
-        "@lvce-editor/ipc": "16.10.0",
-        "@lvce-editor/json-rpc": "8.6.0",
+        "@lvce-editor/assert": "1.7.0",
+        "@lvce-editor/auth-process": "1.10.0",
+        "@lvce-editor/extension-host-helper-process": "0.94.4",
+        "@lvce-editor/ipc": "16.4.0",
+        "@lvce-editor/json-rpc": "8.3.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/process-explorer": "3.14.0",
-        "@lvce-editor/rpc-registry": "9.47.0",
+        "@lvce-editor/process-explorer": "3.12.0",
+        "@lvce-editor/rpc-registry": "9.36.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
-        "markdown-it": "^15.0.0",
+        "markdown-it": "^14.3.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.15.0",
-        "@lvce-editor/file-system-process": "5.11.0",
-        "@lvce-editor/file-watcher-process": "4.12.0",
+        "@lvce-editor/embeds-process": "4.10.0",
+        "@lvce-editor/file-system-process": "5.5.1",
+        "@lvce-editor/file-watcher-process": "4.6.3",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "8.7.0",
-        "@lvce-editor/search-process": "15.6.1",
-        "@lvce-editor/typescript-compile-process": "5.8.0",
+        "@lvce-editor/pty-host": "8.3.0",
+        "@lvce-editor/search-process": "15.1.0",
+        "@lvce-editor/typescript-compile-process": "5.4.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
         "trash": "^10.1.1"
       }
     },
+    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/assert": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
+      "integrity": "sha512-l9fHl7KDYAm4ou/B88fiRYVguA7z5Fx4lC8SmCLuCJFeXfjqPFh7rnGysToPNssmcPAEdwOgXvH+5U4v2V6q5Q==",
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/ipc": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.4.0.tgz",
+      "integrity": "sha512-CxMjWxF/NjoAwa2B5/hFzuXuPVSSTY2tM4khlLopXTqIHbkPJzo6FAAkBI8NRqabchRYCDDpvaO+IvASWwp+Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/verror": "^1.7.0",
+        "@lvce-editor/web-socket-server": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/json-rpc": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.3.0.tgz",
+      "integrity": "sha512-P05TN3OvSVP0LkcG8xE79mGom/i89ttEJq3RfqRwv0sKvSi77NEp9JU3NGANNtBkbFuNWr8s6+XmSmhcj/3ahg==",
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/rpc-registry": {
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.36.0.tgz",
+      "integrity": "sha512-fbV4xYg0jZn06TcicEOm0wM+kA23OXZk+NK3QZsjNCIBdl0Pv6+V0GiR1aAbU+wlMmbLuHkEpmtSXfoBKrbGBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/constants": "^5.19.0",
+        "@lvce-editor/rpc": "^6.4.0"
+      }
+    },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.97.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.97.25.tgz",
-      "integrity": "sha512-qsfSVCKTtxRM1yxwdugTXMY3zsMEDU9GpIii7vbDjEu5Vk75+1YS8XQ6rNIVxGJ/4dUDqy5ZLkI9mrxf17fSQQ==",
+      "version": "0.94.4",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.94.4.tgz",
+      "integrity": "sha512-B/tpOBN+CcXBwjGBakl3L5nXz0OObNbFXdfM4Yqw3wjKC3FYlA7qos5aw0Zwrvy9wNwb5Z1hRGJSfUlhEz1Xvw==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -3940,9 +4181,9 @@
       "link": true
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.8.0.tgz",
-      "integrity": "sha512-kJ/NDVYT/KirvB/qAo8f0rVDJKgaRyCrYZ5c5W8B2bQ4iQLnQ68FHJcIKypRa6vN7bfI544xfl7laqMOhZZ28w==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.4.0.tgz",
+      "integrity": "sha512-nBHfHtqiWTMDJpdsq3xju/RdL8LLH/rsUzcda0y0wbSlmG0PmCOvNIN3LA+FfLX+FpHtDk41JRc7TGZ0vW971Q==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -5240,7 +5481,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/chunkify": {
@@ -5320,13 +5560,12 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -5336,7 +5575,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5469,8 +5707,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -6607,19 +6844,9 @@
       }
     },
     "node_modules/argparse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
-      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -7083,7 +7310,6 @@
       "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
       "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=20"
       },
@@ -7106,7 +7332,6 @@
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -7116,7 +7341,6 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.19.tgz",
       "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/http-cache-semantics": "^4.2.0",
         "get-stream": "^9.0.1",
@@ -7135,7 +7359,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -7152,7 +7375,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -7165,7 +7387,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7338,6 +7559,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/chunk-data": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chunk-data/-/chunk-data-0.1.0.tgz",
+      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chunkify": {
@@ -7542,7 +7775,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7557,14 +7789,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7768,7 +7998,6 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
       "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mimic-response": "^4.0.0"
       },
@@ -8050,12 +8279,12 @@
       }
     },
     "node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=0.12"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -9151,7 +9380,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
@@ -9714,27 +9942,26 @@
       }
     },
     "node_modules/got": {
-      "version": "14.6.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
-      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
+      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@sindresorhus/is": "^7.0.1",
+        "@sindresorhus/is": "^8.0.0",
         "byte-counter": "^0.1.0",
         "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^13.0.12",
+        "cacheable-request": "^13.0.18",
+        "chunk-data": "^0.1.0",
         "decompress-response": "^10.0.0",
-        "form-data-encoder": "^4.0.2",
         "http2-wrapper": "^2.2.1",
-        "keyv": "^5.5.3",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^4.0.1",
+        "keyv": "^5.6.0",
+        "lowercase-keys": "^4.0.1",
         "responselike": "^4.0.2",
-        "type-fest": "^4.26.1"
+        "type-fest": "^5.6.0",
+        "uint8array-extras": "^1.5.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
@@ -9745,19 +9972,20 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/got/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "license": "(MIT OR CC0-1.0)",
-      "optional": true,
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9839,8 +10067,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -9868,7 +10095,6 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
       "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -10179,7 +10405,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10222,7 +10447,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11876,9 +12100,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
-      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -11891,7 +12115,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "uc.micro": "^3.0.0"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -11936,13 +12160,12 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
+      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12020,9 +12243,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
-      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "funding": [
         {
           "type": "github",
@@ -12035,12 +12258,12 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^3.0.0",
-        "entities": "^8.0.0",
-        "linkify-it": "^6.0.0",
-        "mdurl": "^2.1.0",
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
-        "uc.micro": "^3.0.0"
+        "uc.micro": "^2.1.0"
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
@@ -13052,7 +13275,6 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -13077,7 +13299,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -13238,7 +13459,6 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
       "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -13652,7 +13872,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13695,7 +13914,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13993,7 +14211,6 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
       "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "parse-ms": "^4.0.0"
@@ -14109,7 +14326,6 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -14310,8 +14526,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -14351,12 +14566,23 @@
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
       "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/responselike/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14592,7 +14818,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -14605,7 +14830,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15065,6 +15289,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tail": {
@@ -15531,9 +15767,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
-      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
     "node_modules/uglify-js": {
@@ -15548,6 +15784,18 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unbash": {
@@ -15571,7 +15819,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16109,7 +16356,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16193,7 +16439,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "^0.97.25"
+        "@lvce-editor/server": "^0.94.4"
       },
       "devDependencies": {
         "@types/node": "^22.14.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2888,25 +2888,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@lvce-editor/assert": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
-      "integrity": "sha512-l9fHl7KDYAm4ou/B88fiRYVguA7z5Fx4lC8SmCLuCJFeXfjqPFh7rnGysToPNssmcPAEdwOgXvH+5U4v2V6q5Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
+      "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
       "license": "MIT"
-    },
-    "node_modules/@lvce-editor/auth-process": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.10.0.tgz",
-      "integrity": "sha512-GlyU+4vJG88eSRsp9rjcj/ZDGRKR8oYKFAKB7pKA8ovSz9OlS14ddnqlaS5uZ6zpD2u5D6iS2eO78AeSvAaiBg==",
-      "license": "MIT",
-      "bin": {
-        "auth-process": "bin/oauthProcess.js"
-      },
-      "engines": {
-        "node": ">=24"
-      }
     },
     "node_modules/@lvce-editor/command": {
       "version": "2.0.0",
@@ -2921,9 +2910,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.10.0.tgz",
-      "integrity": "sha512-mEKsVl6i/Qd/YQuFvzr6806pg6YIq0vo9AQ1v42U7ir+7sD3y3fvUcEL7yyOrC2+CimeoByj8BTEHHMFJNuB2w==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.15.0.tgz",
+      "integrity": "sha512-Z9B7YS7KAzia8lI1XR4Grx5Rl+OX2ow5PuAePLh1n4gx5BB40VeJX7Jj9scOZRclUQQmhCkH6MQt28jhIXNQ4A==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -3066,146 +3055,29 @@
       "link": true
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.93.21",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.93.21.tgz",
-      "integrity": "sha512-VmUbGjSr2o7BzlRqZfSQbIlT59/XB7SFKipMXXkPp3bZnrJbHhCJWjM2EnNMQ8pgXlKUlX8hancphjfQbjPBFQ==",
+      "version": "0.97.25",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.97.25.tgz",
+      "integrity": "sha512-qwo/5cW0eWbrVvy4+VFOS46XWNdx5DjEOV74Nn5J3A1rubwsiHRvVx4MpTXoWlFUAwJMDd4enmplIfDlrD9DHA==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.7.0",
-        "@lvce-editor/rpc": "^6.8.0",
-        "@lvce-editor/verror": "^1.7.0",
-        "execa": "^9.6.1",
-        "got": "^15.1.0",
-        "minimist": "^1.2.8"
+        "@lvce-editor/assert": "^1.9.0",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.16.0",
+        "@lvce-editor/verror": "^1.7.0"
       },
       "engines": {
         "node": ">=24"
       }
     },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.5.1.tgz",
-      "integrity": "sha512-kmVihRCa4LpcgwC4KN+jtdYuAAn+2UWfjtBaAZmuDLVqElQnn+lExWvjQoD3U2dOble9WU9/Y8uX5ejRI4mJEQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.11.0.tgz",
+      "integrity": "sha512-g1rGvTIBggaG9emayBczibKs+eOJgkOtbgp3TidDpuSwaX7uJotLBCGJNQyu6QhPPLskmkz1d5L4R+7bOzO/oA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "trash": "^10.1.1",
-        "ws": "^8.21.0"
+        "ws": "^8.21.1"
       },
       "bin": {
         "file-system-process": "bin/fileSystemProcess.js"
@@ -3215,9 +3087,9 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.6.3.tgz",
-      "integrity": "sha512-Kjxgiv4HfJ3tDVicgfjzpBQLxZtUs4N5AjcSui3sl9pxvoW6kYhv13BakIaBXlvxpOsHSsbKITRwkCtmu0cJ+g==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.12.0.tgz",
+      "integrity": "sha512-3nLW4QWoH9eLpQ2bcKrawNxH7q2aLbdH0+E19kmlukOTM+HWmIj9dnJKr3zPiOKOnUjE/S0bZwB1gL+2Arbd4g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3239,23 +3111,24 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.5.0.tgz",
-      "integrity": "sha512-SgCmkVlkleWGwKgesKMNI3zlcjS9Hg7sHQ7HsayngbODhtLSUpLb/ZXpw0ziCCZHp377YCw/jwiT4MlzLRRTxw==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
+      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
+        "@lvce-editor/web-socket-server": "^2.1.0",
+        "ws": "^8.21.1"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@lvce-editor/json-rpc": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.4.0.tgz",
-      "integrity": "sha512-P88S6+tTtDTk7esMVwdVxhNeVE0SszWOS6HFflVmza/T/MvKQ88KjYJqTACd+6MWQmw+ZHV8hLwdL+9YXLfIoQ==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.6.0.tgz",
+      "integrity": "sha512-T9zeMKn7Yk6QpMVY/RK5YzCp3VnG53jyHJ7gbC+CukuzlXMngj/TzR1mNkqEK8X3rFG+fxOAHrRKik+EE4cVAQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/jsonc-parser": {
@@ -3424,19 +3297,6 @@
         "open": "^10.1.2"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/@sindresorhus/is": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/execa": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -3521,33 +3381,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/got": {
-      "version": "14.6.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
-      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sindresorhus/is": "^7.0.1",
-        "byte-counter": "^0.1.0",
-        "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^13.0.12",
-        "decompress-response": "^10.0.0",
-        "form-data-encoder": "^4.0.2",
-        "http2-wrapper": "^2.2.1",
-        "keyv": "^5.5.3",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^4.0.1",
-        "responselike": "^4.0.2",
-        "type-fest": "^4.26.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/human-signals": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
@@ -3573,29 +3406,6 @@
       "optional": true,
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/keyv": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3744,19 +3554,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/wsl-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
@@ -3810,9 +3607,9 @@
       }
     },
     "node_modules/@lvce-editor/process-explorer": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.12.0.tgz",
-      "integrity": "sha512-BrGgUrk7BwWS5hm6KczqksVD9bIYVMjaQh2njxt3ZDn2dURXAcNtyfWJlnXelAw7ccUWJXNaS0GlUZxPVG7aXA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.14.0.tgz",
+      "integrity": "sha512-PfJKcKPyqoxOhMJLXFMSTz9mrzWvK+rYgo3lZQQFBdEEwuC/m8laV4eppvKMucWsLJPfTCKFc1gtMqpXfSLUVw==",
       "license": "MIT",
       "bin": {
         "process-explorer": "bin/processExplorer.js"
@@ -3825,11 +3622,14 @@
       }
     },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.3.0.tgz",
-      "integrity": "sha512-g2hTRb7lSc3uZaLq54dthlNG9ANG6eyJYPMih/WMqq+8GSoRblhbZZhsUpJdpaTb7hnwcsJ3y0LK5X8IKm2tDQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.7.0.tgz",
+      "integrity": "sha512-wx/4AUOJJfPVBlgueNrF/lFODN2575KIwfE5vHCl26jFr8qWJHvmypv/91eoq4whA5wGzH+tjEvO4t4FT8GSrg==",
       "license": "MIT",
       "optional": true,
+      "dependencies": {
+        "@lvce-editor/command": "^2.0.0"
+      },
       "bin": {
         "pty-host": "bin/ptyHost.js"
       },
@@ -3838,9 +3638,9 @@
       }
     },
     "node_modules/@lvce-editor/ripgrep": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.4.0.tgz",
-      "integrity": "sha512-9Y6xyk24MuVwz6WDv9SWyxVC351x1H/yHr2yaU5iuf0snnlGKOX4ix/QpniiESDHjlJn74B2V/h6DI4kwxckkQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.5.0.tgz",
+      "integrity": "sha512-k4VM7TG6/dENvTqiuJJZtSr4x9ZCzCnRsUVZFijVexPSvR0JmHY6MC1gAcLeb13kQbtL/CVJZNJ/sk64JSMSeg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3851,14 +3651,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.10.0.tgz",
-      "integrity": "sha512-yOvmhLpnRIbfa0/PmlIUOnP9hWscuYomztFNzj9Rkv/R2QpptmqC/xZKYNONIkT6yg+SWmWnhbl/6q98zxFIZQ==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.16.0.tgz",
+      "integrity": "sha512-NK9k9/L3fWhwy3j3zrG0ffqHE+9SZ7DevvKcTkrrbgKAS3/L/pAJsTI9MuD8F+18oJEncjCmFTr26+CK3aPSgA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.4.0",
+        "@lvce-editor/ipc": "^16.9.0",
         "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
       }
@@ -3867,7 +3667,6 @@
       "version": "9.47.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.47.0.tgz",
       "integrity": "sha512-EmtSPKK3XMt49CeyzLdSv+Ey4umTRIOOS64Inn/mJxCcmRe+bUi4+ik98PAf9Z+AfLiEV3d/Yjgs2IvBzvKJeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -3876,15 +3675,14 @@
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.1.0.tgz",
-      "integrity": "sha512-GlRDR+Mgy/ln2+J1UiYeAvTxkamnVAOXfsJwp6N4SpQllh1+3zKUjDduUIABakoIIP13Fk4InF0b9VQI/wvrew==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.1.tgz",
+      "integrity": "sha512-XQfgR8TK0NN5tnkPnu5mlf7oEe66PwxbfJCCxjFD+XbXRtmYJZpUPitAjkZE5p1awl7RrQMJFUin8uC3mfulig==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@lvce-editor/constants": "^5.14.0",
         "execa": "^9.6.1",
-        "ws": "^8.21.0"
+        "ws": "^8.21.1"
       },
       "bin": {
         "search-process": "bin/searchProcess.js"
@@ -3893,7 +3691,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/ripgrep": "^5.1.0"
+        "@lvce-editor/ripgrep": "^5.2.0"
       }
     },
     "node_modules/@lvce-editor/search-process/node_modules/execa": {
@@ -4020,13 +3818,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.93.21",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.93.21.tgz",
-      "integrity": "sha512-MNVeQgoPTnAeTaiEG6beV1rvwtD0ybAgIUpgE65qPS5BoNw0nDwro817wywVw7sC4P7EwE/RpED9ql6lkmVr0Q==",
+      "version": "0.97.25",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.97.25.tgz",
+      "integrity": "sha512-vA+GU1J8yW929cF7FdgxJBtIMMA2akfJ0ypf5pxOO08wRptZJhrGeCIQY5DBf5hVzKFtexUJQGfzVSje0tBgzw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.93.21",
-        "@lvce-editor/static-server": "0.93.21"
+        "@lvce-editor/shared-process": "0.97.25",
+        "@lvce-editor/static-server": "0.97.25"
       },
       "bin": {
         "server": "bin/server.js"
@@ -4036,79 +3834,47 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.93.21",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.93.21.tgz",
-      "integrity": "sha512-vZHjfttAvPwgW2jZmIe/+UO2lBeX78uQzN5KvYT3zVCdIu2Gc5cQkpHGDzkbKmmX77GtQnr/n9TSzvXWPd0trg==",
+      "version": "0.97.25",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.97.25.tgz",
+      "integrity": "sha512-l5E+I6e1iLObCEzXk41AUjiu26KBnYOwFrbGu5Ba+CiZ9o5OVyzEdUBu7g/t2BvfTSZx6UHPwzV0bQ0PF05vlw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "1.7.0",
-        "@lvce-editor/auth-process": "1.10.0",
-        "@lvce-editor/extension-host-helper-process": "0.93.21",
-        "@lvce-editor/ipc": "16.4.0",
-        "@lvce-editor/json-rpc": "8.3.0",
+        "@lvce-editor/assert": "1.9.0",
+        "@lvce-editor/extension-host-helper-process": "0.97.25",
+        "@lvce-editor/ipc": "16.10.0",
+        "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/process-explorer": "3.12.0",
-        "@lvce-editor/rpc-registry": "9.36.0",
+        "@lvce-editor/process-explorer": "3.14.0",
+        "@lvce-editor/rpc-registry": "9.47.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
-        "markdown-it": "^14.3.0",
+        "markdown-it": "^15.0.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.10.0",
-        "@lvce-editor/file-system-process": "5.5.1",
-        "@lvce-editor/file-watcher-process": "4.6.3",
+        "@lvce-editor/embeds-process": "4.15.0",
+        "@lvce-editor/file-system-process": "5.11.0",
+        "@lvce-editor/file-watcher-process": "4.12.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "8.3.0",
-        "@lvce-editor/search-process": "15.1.0",
-        "@lvce-editor/typescript-compile-process": "5.4.0",
+        "@lvce-editor/pty-host": "8.7.0",
+        "@lvce-editor/search-process": "15.6.1",
+        "@lvce-editor/typescript-compile-process": "5.8.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
         "trash": "^10.1.1"
       }
     },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/ipc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.4.0.tgz",
-      "integrity": "sha512-CxMjWxF/NjoAwa2B5/hFzuXuPVSSTY2tM4khlLopXTqIHbkPJzo6FAAkBI8NRqabchRYCDDpvaO+IvASWwp+Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/json-rpc": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.3.0.tgz",
-      "integrity": "sha512-P05TN3OvSVP0LkcG8xE79mGom/i89ttEJq3RfqRwv0sKvSi77NEp9JU3NGANNtBkbFuNWr8s6+XmSmhcj/3ahg==",
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.36.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.36.0.tgz",
-      "integrity": "sha512-fbV4xYg0jZn06TcicEOm0wM+kA23OXZk+NK3QZsjNCIBdl0Pv6+V0GiR1aAbU+wlMmbLuHkEpmtSXfoBKrbGBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.19.0",
-        "@lvce-editor/rpc": "^6.4.0"
-      }
-    },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.93.21",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.93.21.tgz",
-      "integrity": "sha512-KRidH+zTkOx7KOBawtz2w8xnwlATlCRU3ijNOgbOpQnEVCmqwFFmLZPx8UALVh9MjX1fI10JCxFb+FJdTn9s9A==",
+      "version": "0.97.25",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.97.25.tgz",
+      "integrity": "sha512-qsfSVCKTtxRM1yxwdugTXMY3zsMEDU9GpIii7vbDjEu5Vk75+1YS8XQ6rNIVxGJ/4dUDqy5ZLkI9mrxf17fSQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -4174,9 +3940,9 @@
       "link": true
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.4.0.tgz",
-      "integrity": "sha512-nBHfHtqiWTMDJpdsq3xju/RdL8LLH/rsUzcda0y0wbSlmG0PmCOvNIN3LA+FfLX+FpHtDk41JRc7TGZ0vW971Q==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.8.0.tgz",
+      "integrity": "sha512-kJ/NDVYT/KirvB/qAo8f0rVDJKgaRyCrYZ5c5W8B2bQ4iQLnQ68FHJcIKypRa6vN7bfI544xfl7laqMOhZZ28w==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -5474,6 +5240,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/chunkify": {
@@ -5553,12 +5320,13 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
-      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
       "license": "MIT",
+      "optional": true,
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -5568,6 +5336,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5700,7 +5469,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -6837,9 +6607,19 @@
       }
     },
     "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -7026,9 +6806,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
-      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
+      "integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -7039,7 +6819,7 @@
         "fast-fifo": "^1.3.2"
       },
       "engines": {
-        "bare": ">=1.16.0"
+        "bare": ">=1.28.0"
       },
       "peerDependencies": {
         "bare-buffer": "*"
@@ -7086,9 +6866,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
-      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.7.tgz",
+      "integrity": "sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -7303,6 +7083,7 @@
       "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
       "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=20"
       },
@@ -7325,6 +7106,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -7334,6 +7116,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.19.tgz",
       "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/http-cache-semantics": "^4.2.0",
         "get-stream": "^9.0.1",
@@ -7352,6 +7135,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -7368,6 +7152,7 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -7380,6 +7165,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7552,18 +7338,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/chunk-data": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chunk-data/-/chunk-data-0.1.0.tgz",
-      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chunkify": {
@@ -7768,6 +7542,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7782,12 +7557,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7991,6 +7768,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
       "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^4.0.0"
       },
@@ -8272,12 +8050,12 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -9373,6 +9151,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
@@ -9935,26 +9714,27 @@
       }
     },
     "node_modules/got": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
-      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
+      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@sindresorhus/is": "^8.0.0",
+        "@sindresorhus/is": "^7.0.1",
         "byte-counter": "^0.1.0",
         "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^13.0.18",
-        "chunk-data": "^0.1.0",
+        "cacheable-request": "^13.0.12",
         "decompress-response": "^10.0.0",
+        "form-data-encoder": "^4.0.2",
         "http2-wrapper": "^2.2.1",
-        "keyv": "^5.6.0",
-        "lowercase-keys": "^4.0.1",
+        "keyv": "^5.5.3",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^4.0.1",
         "responselike": "^4.0.2",
-        "type-fest": "^5.6.0",
-        "uint8array-extras": "^1.5.0"
+        "type-fest": "^4.26.1"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
@@ -9965,20 +9745,19 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/got/node_modules/type-fest": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
-      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
+      "optional": true,
       "engines": {
-        "node": ">=20"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10060,7 +9839,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -10088,6 +9868,7 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
       "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -10398,6 +10179,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10440,6 +10222,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12093,9 +11876,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
-      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
       "funding": [
         {
           "type": "github",
@@ -12108,7 +11891,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "uc.micro": "^2.0.0"
+        "uc.micro": "^3.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -12153,12 +11936,13 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
-      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
-        "node": ">=20"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12236,9 +12020,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
-      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
       "funding": [
         {
           "type": "github",
@@ -12251,12 +12035,12 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.5.0",
-        "linkify-it": "^5.0.2",
-        "mdurl": "^2.0.0",
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
         "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
+        "uc.micro": "^3.0.0"
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
@@ -13268,6 +13052,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -13292,6 +13077,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -13452,6 +13238,7 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
       "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -13865,6 +13652,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13907,6 +13695,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14204,6 +13993,7 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
       "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "parse-ms": "^4.0.0"
@@ -14319,6 +14109,7 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -14519,7 +14310,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -14559,23 +14351,12 @@
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
       "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
       "engines": {
         "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/responselike/node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14811,6 +14592,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -14823,6 +14605,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15282,18 +15065,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
-      }
-    },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tail": {
@@ -15760,9 +15531,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
       "license": "MIT"
     },
     "node_modules/uglify-js": {
@@ -15777,18 +15548,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unbash": {
@@ -15812,6 +15571,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16349,6 +16109,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16432,7 +16193,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "^0.93.21"
+        "@lvce-editor/server": "^0.97.25"
       },
       "devDependencies": {
         "@types/node": "^22.14.0"

--- a/packages/e2e/src/extension-detail.large-readme.ts
+++ b/packages/e2e/src/extension-detail.large-readme.ts
@@ -19,6 +19,4 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await expect(headings).toHaveCount(7)
   const safeLink = markdown.locator('a').nth(0)
   await expect(safeLink).toHaveAttribute('href', 'https://example.com/section-01')
-  const image = markdown.locator('img').nth(0)
-  await expect(image).toHaveAttribute('onerror', null)
 }

--- a/packages/e2e/src/extension-detail.readme-image-not-found.ts
+++ b/packages/e2e/src/extension-detail.readme-image-not-found.ts
@@ -17,8 +17,6 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await expect(markDown).toBeVisible()
   await expect(markDown).toContainText('test readme')
   const image = markDown.locator('img[src="./not-found.png"]')
-  await expect(image).toBeVisible()
-  await expect(image).toHaveAttribute('onerror', null)
   await ExtensionDetail.handleMarkdownImageError('./not-found.png')
   const imageError = markDown.locator('.MarkdownImageError')
   await expect(imageError).toBeVisible()

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "^0.97.25"
+    "@lvce-editor/server": "^0.94.4"
   },
   "devDependencies": {
     "@types/node": "^22.14.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "^0.93.21"
+    "@lvce-editor/server": "^0.97.25"
   },
   "devDependencies": {
     "@types/node": "^22.14.0"


### PR DESCRIPTION
Update the static LVCE server stack so the web renderer uses its web-safe application name path. Extension details now load normally in the published static playground.