### PR TITLE
fix: update extension detail after uninstall

### DIFF
--- a/packages/e2e/src/extension-detail.uninstall-extension.ts
+++ b/packages/e2e/src/extension-detail.uninstall-extension.ts
@@ -4,7 +4,7 @@ export const name = 'extension-detail.uninstall-extension'
 
 export const skip = 1
 
-export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator, Main }) => {
   // arrange
   const extensionUri = import.meta.resolve('../fixtures/extension-disable')
   await Extension.addWebExtension(extensionUri)
@@ -17,5 +17,14 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   const disableButton = Locator('.ExtensionDetail [name="Disable"]')
   await expect(disableButton).toBeHidden()
   const enableButton = Locator('.ExtensionDetail [name="Enable"]')
-  await expect(enableButton).toBeVisible()
+  await expect(enableButton).toBeHidden()
+  const uninstallButton = Locator('.ExtensionDetail [name="Uninstall"]')
+  await expect(uninstallButton).toBeHidden()
+
+  await Main.closeActiveEditor()
+  await ExtensionDetail.open('test.extension-enable-error')
+  const errorTitle = Locator('.ExtensionDetailErrorTitle')
+  const errorMessage = Locator('.ExtensionDetailErrorMessage')
+  await expect(errorTitle).toHaveText('Unable to load extension')
+  await expect(errorMessage).toHaveText('The extension "test.extension-enable-error" is not available in this version of LVCE Editor.')
 }

--- a/packages/extension-detail-view-worker/src/parts/HandleClickUninstall/HandleClickUninstall.ts
+++ b/packages/extension-detail-view-worker/src/parts/HandleClickUninstall/HandleClickUninstall.ts
@@ -1,9 +1,18 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../ExtensionDetailState/ExtensionDetailState.ts'
+import { uninstallExtension } from '../UninstallExtension/UninstallExtension.ts'
 
 export const handleClickUninstall = async (state: ExtensionDetailState): Promise<ExtensionDetailState> => {
   const { extension } = state
   const { id } = extension
-  await RendererWorker.uninstallExtension(id)
-  return state
+  try {
+    await uninstallExtension(id)
+    return {
+      ...state,
+      buttons: [],
+    }
+  } catch (error) {
+    await RendererWorker.showErrorDialog(error)
+    return state
+  }
 }

--- a/packages/extension-detail-view-worker/src/parts/UninstallExtension/UninstallExtension.ts
+++ b/packages/extension-detail-view-worker/src/parts/UninstallExtension/UninstallExtension.ts
@@ -1,5 +1,5 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 
-export const uninstallExtension = (id: string): Promise<void> => {
-  return RendererWorker.uninstallExtension(id)
+export const uninstallExtension = async (id: string): Promise<void> => {
+  await ExtensionManagementWorker.uninstall(id)
 }

--- a/packages/extension-detail-view-worker/test/HandleClickUninstall.test.ts
+++ b/packages/extension-detail-view-worker/test/HandleClickUninstall.test.ts
@@ -1,31 +1,37 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExtensionDetailState } from '../src/parts/ExtensionDetailState/ExtensionDetailState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as HandleClickUninstall from '../src/parts/HandleClickUninstall/HandleClickUninstall.ts'
 
-test('handle click uninstall - calls uninstall extension', async () => {
-  using mockRpc = RendererWorker.registerMockRpc({
-    'ExtensionManagement.uninstall': () => {
+test('handle click uninstall - calls uninstall extension and removes extension actions', async () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.uninstall': () => {
       /**/
     },
   })
   const state: ExtensionDetailState = {
     ...createDefaultState(),
+    buttons: [{ enabled: true, label: 'Uninstall', name: 'Uninstall', onClick: 'handleClickUninstall' }],
     extension: {
       id: 'test-id',
       uri: 'test://sample-folder',
     },
   }
-  await HandleClickUninstall.handleClickUninstall(state)
+  const result = await HandleClickUninstall.handleClickUninstall(state)
 
-  expect(mockRpc.invocations).toEqual([['ExtensionManagement.uninstall', 'test-id']])
+  expect(mockRpc.invocations).toEqual([['Extensions.uninstall', 'test-id']])
+  expect(result.buttons).toEqual([])
 })
 
-test('handle click uninstall - returns state unchanged', async () => {
-  using mockRpc = RendererWorker.registerMockRpc({
-    'ExtensionManagement.uninstall': () => {
-      /**/
+test('handle click uninstall - shows an error dialog and returns state unchanged when uninstall fails', async () => {
+  const error = new Error('Failed to uninstall extension')
+  using rendererWorker = RendererWorker.registerMockRpc({
+    'ErrorHandling.showErrorDialog'() {},
+  })
+  using extensionManagementWorker = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.uninstall': () => {
+      throw error
     },
   })
   const state: ExtensionDetailState = {
@@ -38,5 +44,6 @@ test('handle click uninstall - returns state unchanged', async () => {
   const result = await HandleClickUninstall.handleClickUninstall(state)
 
   expect(result).toBe(state)
-  expect(mockRpc.invocations).toEqual([['ExtensionManagement.uninstall', 'test-id']])
+  expect(extensionManagementWorker.invocations).toEqual([['Extensions.uninstall', 'test-id']])
+  expect(rendererWorker.invocations).toEqual([['ErrorHandling.showErrorDialog', error]])
 })

--- a/packages/extension-detail-view-worker/test/UninstallExtension.test.ts
+++ b/packages/extension-detail-view-worker/test/UninstallExtension.test.ts
@@ -1,24 +1,24 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import * as UninstallExtension from '../src/parts/UninstallExtension/UninstallExtension.ts'
 
 test('uninstall extension', async () => {
-  using mockRpc = RendererWorker.registerMockRpc({
-    'ExtensionManagement.uninstall': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.uninstall': () => {
       /**/
     },
   })
   await UninstallExtension.uninstallExtension('test-id')
-  expect(mockRpc.invocations).toEqual([['ExtensionManagement.uninstall', 'test-id']])
+  expect(mockRpc.invocations).toEqual([['Extensions.uninstall', 'test-id']])
 })
 
 test('handles error during uninstall', async () => {
   const error = new Error('Failed to uninstall extension')
-  using mockRpc = RendererWorker.registerMockRpc({
-    'ExtensionManagement.uninstall': () => {
+  using mockRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.uninstall': () => {
       throw error
     },
   })
   await expect(UninstallExtension.uninstallExtension('test-id')).rejects.toThrow('Failed to uninstall extension')
-  expect(mockRpc.invocations).toEqual([['ExtensionManagement.uninstall', 'test-id']])
+  expect(mockRpc.invocations).toEqual([['Extensions.uninstall', 'test-id']])
 })


### PR DESCRIPTION
Route extension-detail uninstall through the extension-management worker, clear stale actions after success, and surface uninstall failures.