### PR TITLE
Update ESLint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^18.0.0",
-        "eslint": "^10.8.0",
+        "@lvce-editor/eslint-config": "^18.2.0",
+        "eslint": "^10.8.1",
         "knip": "^6.29.0",
         "prettier": "^3.9.6",
         "typescript": "^6.0.3"
@@ -2915,9 +2915,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.25.0.tgz",
-      "integrity": "sha512-zgpiSbpQgA07YeiQSzApidBUB9DwenxBksXafJbehbxoNXfqNw2tDiZLifd5Y09PGz/cJhebVQCU2jvw55c4SA==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.26.0.tgz",
+      "integrity": "sha512-vh+dSf+oLjS+ekKOnHHDuP8NUSM3ps/Ir15yCJlGDFw82ZqQeWqAiJyIx3Gsa2XDw77ZKDVfxr9wTHgPIaRu3g==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
@@ -2934,9 +2934,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-18.0.0.tgz",
-      "integrity": "sha512-Q1GuQAuyRga4uuvLeucGZkV68QnDfFzNbqJ4F2q83iN1wWphnSsCn0Snwg7Ky+FmZ89bIh218cVdia63kMZhvQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-18.2.0.tgz",
+      "integrity": "sha512-depjU3Z65NieU9IHl3xNUZIrP1Xt1AwQf6n9CEQxefGFttsx6XoW/CQ2BaBRD5ROTsYiSVXM9kaJF4g24TuX2Q==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2948,16 +2948,16 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "18.0.0",
-        "@lvce-editor/eslint-plugin-e2e": "18.0.0",
-        "@lvce-editor/eslint-plugin-eslint-config": "18.0.0",
-        "@lvce-editor/eslint-plugin-extension-json": "18.0.0",
-        "@lvce-editor/eslint-plugin-github-actions": "18.0.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "18.0.0",
-        "@lvce-editor/eslint-plugin-regex": "18.0.0",
-        "@lvce-editor/eslint-plugin-rpc": "18.0.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "18.0.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "18.0.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "18.2.0",
+        "@lvce-editor/eslint-plugin-e2e": "18.2.0",
+        "@lvce-editor/eslint-plugin-eslint-config": "18.2.0",
+        "@lvce-editor/eslint-plugin-extension-json": "18.2.0",
+        "@lvce-editor/eslint-plugin-github-actions": "18.2.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "18.2.0",
+        "@lvce-editor/eslint-plugin-regex": "18.2.0",
+        "@lvce-editor/eslint-plugin-rpc": "18.2.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "18.2.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "18.2.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -2972,9 +2972,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-18.0.0.tgz",
-      "integrity": "sha512-NjgwH2NKwU3MFfsaMkf/eeOKlYdQMqhgyJiRvslhPcZL8lyzgVP5P88AE7pEXr/ZnamzEQOEtrtzH28Z1KBPjA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-18.2.0.tgz",
+      "integrity": "sha512-oGP5M6eRRNsxBNdeEWJHdB2lUU7MBlUKkSO9laZhdw8sz52cCTldh75IN3+Xj/WUN7tkHgN+RybfxjhfLzOg9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2982,23 +2982,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-18.0.0.tgz",
-      "integrity": "sha512-W5SvLvHQVWR5aV+QJPTT/QRPbBHEoFyYY8zbAeaxwP3TpHmhdrJTHY0Ser8ZAKC8VzxhvpWOaVokgJWGMH6dmA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-18.2.0.tgz",
+      "integrity": "sha512-AIpv+tOAMqH+rBK/Mx7P7pzKpF3YnS3xCZJBoHxx4VdWBSMrhTNQJvkXdhIZIgu9uGKU6FbBTq+o9FBk1jTfhw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-eslint-config": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-eslint-config/-/eslint-plugin-eslint-config-18.0.0.tgz",
-      "integrity": "sha512-zZUDZdU8svl+cZ391YprAKNYULR/4nvtnJsDbi2RWEwhvixyXZLWEmakguFpav1g0xD+KfR95O+qddwtik3yow==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-eslint-config/-/eslint-plugin-eslint-config-18.2.0.tgz",
+      "integrity": "sha512-yVwr5EunNy7lh4sCaeu6y0/jYpMTqgP/S7lZOMz4OUn26skMxF+weRFjIKiADvx2FC65YkrWDx7eC0fRtk3AEA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-extension-json": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-18.0.0.tgz",
-      "integrity": "sha512-FWK97+EyJdgaocSo5eRbMLobOO0IsEYD7krxZdpP+VUHzkXKRg50dnDOThWdAVTBba4fq/ld3kURgsymuIfQDg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-18.2.0.tgz",
+      "integrity": "sha512-Z6A3jwLDvUsDaP2AMZ80QCr7xGVCsJY5MPj4K5hMR6BeXm2nBqv4bp+NFFFFh9fcvzhh3Lf1Uq+r/uwAsL8p5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3006,9 +3006,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-18.0.0.tgz",
-      "integrity": "sha512-5lorIivbeHoc/iAYfCY6Y3XFJ0jNc7zsqxQroAInQUlhTIeK8BNCjnkQIv4J1UiUkR0peGjddqmKmLYiVTPuKw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-18.2.0.tgz",
+      "integrity": "sha512-jzC9qzB6wl7lQREaiW1EWWIp8G+eOF6M71R3Xj6qGAbGhAbDvb/MOEHQsLZW/DBUTtDyskC7LU9UvxmxPE2H1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3017,9 +3017,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-18.0.0.tgz",
-      "integrity": "sha512-ATg67BM6gcOt8f2AvabsKKh8NzZezN+lM19ZAoZUuVGClciVqDVibAjbvmlLnTy4vxWq8uyTDcTvAuS/A0PKOg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-18.2.0.tgz",
+      "integrity": "sha512-fybjUNLG3Jk+4dHn9Jyj94EzFMN8f1HP0avE2o8IIGFbR5B3lBw49Hz9aRQEZMy8l4vbk3OtKC9h3q6t1sQ38w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3027,23 +3027,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-18.0.0.tgz",
-      "integrity": "sha512-cuzNaGpak6XNsZSmJCLldougHiyjwGSZEEqxx3iCxrfW1/b1RCpaIuUBQGIdmBEF09Ql8QN3uHcnvaG1pl1LAw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-18.2.0.tgz",
+      "integrity": "sha512-Cm++lkCreG53R73iocNfXLOa/uVLjKRDugQBWV4sy2XVgyZvsZWeCKZWBfMsN+LP3MRVj2p0Fzlbi5ywHI47YQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-18.0.0.tgz",
-      "integrity": "sha512-c5SmTTzfKxL00a+CC5/Bz1pi1DZwXGVj2hOZszs70jVxKissYGaJXtlcuqC1LJXqzrUBJmcqe/cmlFlKIJhphg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-18.2.0.tgz",
+      "integrity": "sha512-mPhh+IAk7NnlcuSfFLDclypKlY0PwBjJNc3hPn2Wma24Ww3kHwlU+p1SlvU/jU5T12kBcqb60djIseBL03xBnw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-18.0.0.tgz",
-      "integrity": "sha512-OibcGVrGkpgXkJBSs1Aix+rm6TlCBZuR3C4A0DdxJlABdPpKLeLYGpGaR8bIwBunnivmKjJPaYPA0KCRW8S+tw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-18.2.0.tgz",
+      "integrity": "sha512-nj9Rsrdbpdzqd4WrvGYWFCKOSALn/iqPrSHeyyQqpUf2+ZzsZxmy2pnnbCGuNozZ3BRr8AazwliygPcYflJIcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3051,9 +3051,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-18.0.0.tgz",
-      "integrity": "sha512-ueMuPSpbG1iAU4CF1SB/vwX1RSkSgx9nue/89tzGmn9UzAwJfLU4neSc5b+zo9vTVnNQ+4Jp38VFbhoz1BgFsA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-18.2.0.tgz",
+      "integrity": "sha512-bFPELVF4H7uSUDS7gQ4v2naq8gfJ+aTA0upxCkVxPkbrl2j+7sZP6aTtL6Tl+i90VnEZ57sJeJUu0DXjETDt5Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3865,14 +3865,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.47.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.47.0.tgz",
-      "integrity": "sha512-EmtSPKK3XMt49CeyzLdSv+Ey4umTRIOOS64Inn/mJxCcmRe+bUi4+ik98PAf9Z+AfLiEV3d/Yjgs2IvBzvKJeg==",
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.49.0.tgz",
+      "integrity": "sha512-jcKRap3Pb9TI4R0UWLpGaDghwVOt4zJSCsuFXw9YD3XaqJrJJQ3xXa0coJFoQoyXpPGDNCWZCOCW3wUF0LDA0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.25.0",
+        "@lvce-editor/constants": "^5.26.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
@@ -8406,9 +8406,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -16415,7 +16415,7 @@
         "@lvce-editor/constants": "^5.20.0",
         "@lvce-editor/i18n": "^2.5.0",
         "@lvce-editor/rpc": "^6.10.0",
-        "@lvce-editor/rpc-registry": "^9.47.0",
+        "@lvce-editor/rpc-registry": "^9.49.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
         "@lvce-editor/virtual-dom-worker": "^11.8.1",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "printWidth": 150
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^18.0.0",
-    "eslint": "^10.8.0",
+    "@lvce-editor/eslint-config": "^18.2.0",
+    "eslint": "^10.8.1",
     "knip": "^6.29.0",
     "prettier": "^3.9.6",
     "typescript": "^6.0.3"


### PR DESCRIPTION
## Summary
- update ESLint to 10.8.1
- update `@lvce-editor/eslint-config` to 18.2.0
- refresh stale `rpc-registry` and `constants` lock entries so `npm ci` matches the workspace manifests

## Validation
- `npm ci`
- `npm run lint`