### PR TITLE
Capitalize activated runtime status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3865,9 +3865,9 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.49.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.49.0.tgz",
-      "integrity": "sha512-jcKRap3Pb9TI4R0UWLpGaDghwVOt4zJSCsuFXw9YD3XaqJrJJQ3xXa0coJFoQoyXpPGDNCWZCOCW3wUF0LDA0g==",
+      "version": "9.50.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.50.0.tgz",
+      "integrity": "sha512-3KAKtB9Xr8txUrrivaDtwxVw3MOUoJaH4FA1QZfz1IJVR7euXND4TJKxMStGTCpMKUm02m7Y0a2A0/8USgxZsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16415,7 +16415,7 @@
         "@lvce-editor/constants": "^5.20.0",
         "@lvce-editor/i18n": "^2.5.0",
         "@lvce-editor/rpc": "^6.10.0",
-        "@lvce-editor/rpc-registry": "^9.49.0",
+        "@lvce-editor/rpc-registry": "^9.50.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.5.0",
         "@lvce-editor/virtual-dom-worker": "^11.8.1",

--- a/packages/e2e/src/extension-detail.feature-activated-runtime-status.ts
+++ b/packages/e2e/src/extension-detail.feature-activated-runtime-status.ts
@@ -18,7 +18,7 @@ export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }
   await expect(heading).toBeVisible()
   await expect(heading).toHaveText('Runtime Status')
   const definitionList = Locator('.FeatureContent dl')
-  await expect(definitionList).toContainText('Status: activated')
+  await expect(definitionList).toContainText('Status: Activated')
   await expect(definitionList).toContainText('Activation Event: onCommand:runtimeStatus.activate')
   await expect(definitionList).toContainText('Activation Time: ')
 }

--- a/packages/extension-detail-view-worker/src/parts/GetStatusMessage/GetStatusMessage.ts
+++ b/packages/extension-detail-view-worker/src/parts/GetStatusMessage/GetStatusMessage.ts
@@ -3,7 +3,7 @@ import * as RuntimeStatusType from '../RuntimeStatusType/RuntimeStatusType.ts'
 export const getStatusMessage = (statusType: number): string => {
   switch (statusType) {
     case RuntimeStatusType.Activated:
-      return 'activated'
+      return 'Activated'
     case RuntimeStatusType.Activating:
       return 'Activating'
     case RuntimeStatusType.Disabled:

--- a/packages/extension-detail-view-worker/test/FeatureRuntimeStatusVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/FeatureRuntimeStatusVirtualDom.test.ts
@@ -53,7 +53,7 @@ test('getRuntimeStatusVirtualDom should return correct virtual DOM structure wit
   })
   expect(result[7]).toEqual({
     childCount: 0,
-    text: 'activated',
+    text: 'Activated',
     type: VirtualDomElements.Text,
   })
   expect(result[8]).toEqual({

--- a/packages/extension-detail-view-worker/test/GetStatusMessage.test.ts
+++ b/packages/extension-detail-view-worker/test/GetStatusMessage.test.ts
@@ -17,9 +17,9 @@ test('getStatusMessage should return "Activating" for RuntimeStatusType.Activati
   expect(result).toBe('Activating')
 })
 
-test('getStatusMessage should return "activated" for RuntimeStatusType.Activated', () => {
+test('getStatusMessage should return "Activated" for RuntimeStatusType.Activated', () => {
   const result = getStatusMessage(RuntimeStatusType.Activated)
-  expect(result).toBe('activated')
+  expect(result).toBe('Activated')
 })
 
 test('getStatusMessage should return "Disabled" for RuntimeStatusType.Disabled', () => {

--- a/packages/extension-detail-view-worker/test/GetStatusVirtualDom.test.ts
+++ b/packages/extension-detail-view-worker/test/GetStatusVirtualDom.test.ts
@@ -24,7 +24,7 @@ test('getStatusVirtualDom should return correct virtual DOM structure for activa
     },
     {
       childCount: 0,
-      text: 'activated',
+      text: 'Activated',
       type: VirtualDomElements.Text,
     },
   ]


### PR DESCRIPTION
Capitalizes the activated runtime-status label in the extension detail view and updates its focused unit, virtual-DOM, and e2e coverage. Also synchronizes the root lockfile with the rpc-registry version already declared on main so CI can install dependencies.